### PR TITLE
Remove HLint and Weeder support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: freckle/stack-action@main
+      - uses: freckle/stack-action@v3
 ```
 
 ## Inputs
@@ -38,17 +38,33 @@ jobs:
 
 - `stack-arguments`: additional arguments for stack invocation.
 
-- `hlint`: whether to run install and `hlint` (default `true`)
+## HLint & Weeder
 
-- `hlint-version`: install a specific version of HLint (default latest)
+Previous versions of this Action ran HLint and Weeder for you. We recommend
+doing that as separate actions now, so those options have been removed.
 
-- `hlint-arguments`: arguments to pass to `hlint` (default `.`)
+Here is an example of running separate Actions:
 
-- `weeder`: whether to run install and `weeder` (default `true`)
+```yaml
+jobs:
+  test:
+    # ...
+    steps:
+      - uses: actions/checkout@v2
+      - uses: freckle/stack-cache-action@v1
+      - uses: freckle/stack-action@v3
 
-- `weeder-version`: install a specific version of Weeder (default latest)
+      # Weeder needs compilation artifacts, so it must still be the same Job
+      - uses: freckle/weeder-action@v1
 
-- `weeder-arguments`: arguments to pass to `weeder` (default none)
+  # But HLint can be a distinct Job, which affords more flexibility
+  hlint:
+    # ...
+    steps:
+      - uses: actions/checkout@v2
+      - uses: rwe/actions-hlint-setup@v1
+      - uses: rwe/actions-hlint-run@v2
+```
 
 ---
 

--- a/action.yml
+++ b/action.yml
@@ -21,30 +21,6 @@ inputs:
     description: "Additional arguments for stack invocations"
     required: true
     default: ""
-  hlint:
-    description: "Run HLint"
-    required: true
-    default: true
-  hlint-version:
-    description: "Install a specific version of HLint"
-    required: true
-    default: ""
-  hlint-arguments:
-    description: "Arguments to pass to HLint"
-    required: true
-    default: "."
-  weeder:
-    description: "Run Weeder"
-    required: true
-    default: true
-  weeder-version:
-    description: "Install a specific version of Weeder"
-    required: true
-    default: ""
-  weeder-arguments:
-    description: "Arguments to pass to Weeder"
-    required: true
-    default: ""
 outputs: {}
 runs:
   using: composite
@@ -55,22 +31,6 @@ runs:
       working-directory: ${{ inputs.working-directory }}
       run: |
         stack --no-terminal setup
-
-        if ${{ inputs.hlint }}; then
-          if [[ -n "${{ inputs.hlint-version }}" ]]; then
-            stack --no-terminal install --copy-compiler-tool hlint-${{ inputs.hlint-version }}
-          else
-            stack --no-terminal install --copy-compiler-tool hlint
-          fi
-        fi
-
-        if ${{ inputs.weeder }}; then
-          if [[ -n "${{ inputs.weeder-version }}" ]]; then
-            stack --no-terminal install --copy-compiler-tool weeder-${{ inputs.weeder-version }}
-          else
-            stack --no-terminal install --copy-compiler-tool weeder
-          fi
-        fi
 
         stack_arguments=()
 
@@ -107,15 +67,3 @@ runs:
         stack --no-terminal --stack-yaml ${{ inputs.stack-yaml }} \
           build ${{ steps.setup.outputs.stack-arguments }} --test \
           ${{ inputs.stack-arguments }}
-
-    - name: Lint
-      shell: bash
-      working-directory: ${{ inputs.working-directory }}
-      run: |
-        if ${{ inputs.hlint }}; then
-          stack exec hlint -- ${{ inputs.hlint-arguments }}
-        fi
-
-        if ${{ inputs.weeder }}; then
-          stack exec weeder -- ${{ inputs.weeder-arguments }}
-        fi


### PR DESCRIPTION
We think it's better to perform linting via distinct actions:

- A dedicated Action can have space for more complicated behavior and
  options, such as a problem matcher for in-line annotations
- A dedicated Action could be a dedicated Job, which affords more
  flexibility in if/how it fails the Build
- Dedicated Actions can still (finally) be composed into other Composite
  Actions
