### PR TITLE
Automatically add --resolver nightly

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ jobs:
 
 - `stack-arguments`: additional arguments for stack invocation.
 
+  Default is none, except if `stack-yaml` is the string `"stack-nightly.yaml"`,
+  in which case `--resolver nightly` will be used.
+
 ## Outputs
 
 Every value from `stack path` is set as an output. This can be useful, for

--- a/action.yml
+++ b/action.yml
@@ -115,6 +115,12 @@ runs:
           stack_arguments+=( --pedantic )
         fi
 
+        if [[ "${{ inputs.stack-yaml }}" == 'stack-nightly.yaml' ]]; then
+          if [[ "${stack_arguments[*]}" != *'--resolver'* ]]; then
+            stack_arguments+=( --resolver nightly )
+          fi
+        fi
+
         echo "::set-output name=stack-arguments::${stack_arguments[*]}"
 
     - name: Dependencies


### PR DESCRIPTION
It's not supported to put "resolver: nightly" into a stack.yaml; you
have to pick a specific "nightly-YYYY-MM-DD". This means you can't
simply run --stack-yaml stack-nightly.yaml and expect that to actually
run with an up-to-date nightly. You need to add --resolver nightly too.

This has lead to CI setups with a nightly job outside the main matrix,
since that job (and only that job) needs a special stack-arguments.

With this little bit of convenience, we can add our stack-nightly.yaml
into the main matrix and it Just Works.
