### PR TITLE
In-line caching

### DIFF
--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -5,6 +5,10 @@ on:
   push:
     branches: main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 defaults:
   run:
     working-directory: example
@@ -33,16 +37,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: freckle/stack-cache-action@v2
-        with:
-          prefix: ${{ matrix.runner }}/${{ matrix.resolver }}/
-          working-directory: example
-
       - id: stack
         uses: ./
         with:
           working-directory: example
           stack-arguments: --resolver ${{ matrix.resolver }}
+          cache-prefix: ${{ matrix.resolver }}/
 
       - if: ${{ runner.os != 'windows' }}
         run: |
@@ -82,29 +82,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: freckle/stack-cache-action@v2
-        with:
-          working-directory: example
-          stack-yaml: stack-nightly.yaml
-
       - id: stack
         uses: ./
         with:
           working-directory: example
           stack-yaml: stack-nightly.yaml
+          cache-prefix: auto-nightly/
 
   test-auto-nightly-with-explicit:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: freckle/stack-cache-action@v2
-        with:
-          working-directory: example
-          stack-yaml: stack-nightly.yaml
-
       - id: stack
         uses: ./
         with:
           working-directory: example
           stack-yaml: stack-nightly.yaml
           stack-arguments: --resolver nightly
+          cache-prefix: auto-nightly-explicit/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/README.md
+++ b/README.md
@@ -10,8 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: freckle/stack-action@v3
+      - uses: freckle/stack-action@v4
 ```
+
+**NOTE**: as of version 4, this action automatically handles caching. You do not
+need to use a separate `stack-cache-action` step any more.
 
 ## Inputs
 
@@ -43,6 +46,10 @@ jobs:
   Default is none, except if `stack-yaml` is the string `"stack-nightly.yaml"`,
   in which case `--resolver nightly` will be used.
 
+- `cache-prefix`: prefix applied to all cache keys. This can be any value you
+  like, but teams often use `v{N} and bump it to `v{N+1}` when/if they need to
+  explicitly bust caches. The default is empty.
+
 ## Outputs
 
 `compiler` (e.g. `ghc-9.2.5`) and `compiler-version` (e.g. `9.2.5`) are set from
@@ -51,7 +58,7 @@ actions depend on it:
 
 ```yaml
 - id: stack
-  uses: freckle/stack-action@v3
+  uses: freckle/stack-action@v4
 - uses: freckle/weeder-action@v2
   with:
     ghc-version: ${{ steps.stack.outputs.compiler-version }}
@@ -62,7 +69,7 @@ for example, to upload executables or coverage reports:
 
 ```yaml
 - id: stack
-  uses: freckle/stack-action@v3
+  uses: freckle/stack-action@v4
   with:
     stack-arguments: --copy-bins --coverage
 
@@ -91,7 +98,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - id: stack
-        uses: freckle/stack-action@v3
+        uses: freckle/stack-action@v4
 
       # Weeder requires running in the same Job (to access .hie artifacts)
       - uses: freckle/weeder-action@v2

--- a/README.md
+++ b/README.md
@@ -90,10 +90,9 @@ jobs:
     # ...
     steps:
       - uses: actions/checkout@v3
-      - uses: freckle/stack-cache-action@v2
       - id: stack
         uses: freckle/stack-action@v3
-        
+
       # Weeder requires running in the same Job (to access .hie artifacts)
       - uses: freckle/weeder-action@v2
         with:

--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,9 @@ inputs:
     description: "Additional arguments for stack invocations"
     required: true
     default: ""
+  cache-prefix:
+    required: true
+    default: ""
 outputs:
   compiler:
     description: "compiler.actual value from stack query"
@@ -112,9 +115,6 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: |
-        stack --no-terminal --stack-yaml ${{ inputs.stack-yaml }} \
-          setup
-
         resolver_nightly=
 
         # Extra arguments for build and test steps, not the dependencies step
@@ -141,16 +141,74 @@ runs:
         echo "resolver-nightly=$resolver_nightly" >>"$GITHUB_OUTPUT"
         echo "stack-build-arguments=${stack_build_arguments[*]}" >>"$GITHUB_OUTPUT"
 
+        echo 'stack-works<<EOM' >>"$GITHUB_OUTPUT"
+        # We can't just list out '**/.stack-work' because the files may not
+        # exist at the time of restoring (we want to restore them after all), so
+        # we look for the package manifests and assume there should be a
+        # .stack-work alongside each. There are lots of simpler ways to do this,
+        # but only find-regex works on a default OSX system. Sigh.
+        find . -regex '.*/\(package\.yaml\|.*\.cabal\)$' |
+          while IFS=$'\n' read -r path; do
+            dir=$(dirname "$path" | sed 's%^\./\?%%')
+
+            if [[ -n "$dir" ]]; then
+              # If dir is empty, that means ./.stack-work. We'll always add
+              # that explicitly and printing it through this loop would produce
+              # "...//.stack-work" anyway, which we don't want.
+              echo "${{ inputs.working-directory }}/$dir/.stack-work"
+            fi
+          done | sort -u >>"$GITHUB_OUTPUT"
+
+        # Always include a top-level .stack-work
+        echo "${{ inputs.working-directory }}/.stack-work" >>"$GITHUB_OUTPUT"
+        echo 'EOM' >>"$GITHUB_OUTPUT"
+
+        echo "package-hash=${{ hashFiles(inputs.stack-yaml, '**/package.yaml', '**/*.cabal') }}" >>"$GITHUB_OUTPUT"
+        echo "sources-hash=${{ hashFiles('**', '!**/.stack-work') }}" >>"$GITHUB_OUTPUT"
+
+    - name: Restore dependencies cache
+      id: restore-deps
+      uses: actions/cache/restore@v3
+      with:
+        path: |
+          ~/.stack
+          ${{ steps.setup.outputs.stack-works }}
+        key: ${{ inputs.cache-prefix }}${{ runner.os }}-stack-deps-${{ steps.setup.outputs.package-hash }}
+        restore-keys: |
+          ${{ inputs.cache-prefix }}${{ runner.os }}-stack-deps-
+
     - name: Dependencies
+      if: steps.restore-deps.outputs.cache-hit != 'true'
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: |
+        stack --no-terminal --stack-yaml ${{ inputs.stack-yaml }} setup
         stack --no-terminal --stack-yaml ${{ inputs.stack-yaml }} \
           ${{ steps.setup.outputs.resolver-nightly }} \
           build --dependencies-only --test --no-run-tests \
           ${{ inputs.stack-arguments }}
 
+    - name: Save dependencies cache
+      if: steps.restore-deps.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v3
+      with:
+        path: |
+          ~/.stack
+          ${{ steps.setup.outputs.stack-works }}
+        key: ${{ inputs.cache-prefix }}${{ runner.os }}-stack-deps-${{ steps.setup.outputs.package-hash }}
+
+    - name: Restore build cache
+      id: restore-build
+      uses: actions/cache/restore@v3
+      with:
+        path: ${{ steps.setup.outputs.stack-works }}
+        key: ${{ inputs.cache-prefix }}${{ runner.os }}-stack-build-${{ steps.setup.outputs.package-hash }}-${{ steps.setup.outputs.sources-hash }}
+        restore-keys: |
+          ${{ inputs.cache-prefix }}${{ runner.os }}-stack-build-${{ steps.setup.outputs.package-hash }}-
+          ${{ inputs.cache-prefix }}${{ runner.os }}-stack-build-
+
     - name: Build
+      if: steps.restore-build.outputs.cache-hit != 'true'
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: |
@@ -159,6 +217,13 @@ runs:
           build ${{ steps.setup.outputs.stack-build-arguments }} \
           --test --no-run-tests \
           ${{ inputs.stack-arguments }}
+
+    - name: Save build cache
+      if: steps.restore-build.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v3
+      with:
+        path: ${{ steps.setup.outputs.stack-works }}
+        key: ${{ inputs.cache-prefix }}${{ runner.os }}-stack-build-${{ steps.setup.outputs.package-hash }}-${{ steps.setup.outputs.sources-hash }}
 
     - name: Test
       if: ${{ inputs.test == 'true' }}


### PR DESCRIPTION
By doing this ourselves we can:

- Store a "setup" cache around setup/dependencies
- Store the build cache before running tests
- Fully no-op on complete cache hits

This should increase cache hits and decrease run time substantially.