### PR TITLE
Don't fall back to "any" cache

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -183,7 +183,9 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: |
-        stack --no-terminal --stack-yaml ${{ inputs.stack-yaml }} setup
+        stack --no-terminal --stack-yaml ${{ inputs.stack-yaml }} \
+          ${{ steps.setup.outputs.resolver-nightly }} \
+          setup
         stack --no-terminal --stack-yaml ${{ inputs.stack-yaml }} \
           ${{ steps.setup.outputs.resolver-nightly }} \
           build --dependencies-only --test --no-run-tests \

--- a/action.yml
+++ b/action.yml
@@ -163,7 +163,8 @@ runs:
         echo "${{ inputs.working-directory }}/.stack-work" >>"$GITHUB_OUTPUT"
         echo 'EOM' >>"$GITHUB_OUTPUT"
 
-        echo "package-hash=${{ hashFiles(inputs.stack-yaml, '**/package.yaml', '**/*.cabal') }}" >>"$GITHUB_OUTPUT"
+        echo "snapshot-hash=${{ hashFiles(inputs.stack-yaml) }}" >>"$GITHUB_OUTPUT"
+        echo "package-hash=${{ hashFiles('**/package.yaml', '**/*.cabal') }}" >>"$GITHUB_OUTPUT"
         echo "sources-hash=${{ hashFiles('**', '!**/.stack-work') }}" >>"$GITHUB_OUTPUT"
 
     - name: Restore dependencies cache
@@ -173,9 +174,9 @@ runs:
         path: |
           ~/.stack
           ${{ steps.setup.outputs.stack-works }}
-        key: ${{ inputs.cache-prefix }}${{ runner.os }}-stack-deps-${{ steps.setup.outputs.package-hash }}
+        key: ${{ inputs.cache-prefix }}${{ runner.os }}-stack-deps-${{ steps.setup.outputs.snapshot-hash }}-${{ steps.setup.outputs.package-hash }}
         restore-keys: |
-          ${{ inputs.cache-prefix }}${{ runner.os }}-stack-deps-
+          ${{ inputs.cache-prefix }}${{ runner.os }}-stack-deps-${{ steps.setup.outputs.snapshot-hash }}-
 
     - name: Dependencies
       if: steps.restore-deps.outputs.cache-hit != 'true'
@@ -195,17 +196,17 @@ runs:
         path: |
           ~/.stack
           ${{ steps.setup.outputs.stack-works }}
-        key: ${{ inputs.cache-prefix }}${{ runner.os }}-stack-deps-${{ steps.setup.outputs.package-hash }}
+        key: ${{ inputs.cache-prefix }}${{ runner.os }}-stack-deps-${{ steps.setup.outputs.snapshot-hash }}-${{ steps.setup.outputs.package-hash }}
 
     - name: Restore build cache
       id: restore-build
       uses: actions/cache/restore@v3
       with:
         path: ${{ steps.setup.outputs.stack-works }}
-        key: ${{ inputs.cache-prefix }}${{ runner.os }}-stack-build-${{ steps.setup.outputs.package-hash }}-${{ steps.setup.outputs.sources-hash }}
+        key: ${{ inputs.cache-prefix }}${{ runner.os }}-stack-build-${{ steps.setup.outputs.snapshot-hash }}-${{ steps.setup.outputs.package-hash }}-${{ steps.setup.outputs.sources-hash }}
         restore-keys: |
-          ${{ inputs.cache-prefix }}${{ runner.os }}-stack-build-${{ steps.setup.outputs.package-hash }}-
-          ${{ inputs.cache-prefix }}${{ runner.os }}-stack-build-
+          ${{ inputs.cache-prefix }}${{ runner.os }}-stack-build-${{ steps.setup.outputs.snapshot-hash }}-${{ steps.setup.outputs.package-hash }}-
+          ${{ inputs.cache-prefix }}${{ runner.os }}-stack-build-${{ steps.setup.outputs.snapshot-hash }}-
 
     - name: Build
       if: steps.restore-build.outputs.cache-hit != 'true'


### PR DESCRIPTION
Separate the `stack.yaml` from the `package.yaml` one and only fall back
as far as the same `stack.yaml`. In multi-`stack-yaml` projects, which
are common, the old behavior could lead to a lot of cross-cache errors.
Therefore, taking it into account this way is a safer default.

NOTE: If `stack-arguments` should be taken into account, users are
expected to do that themselves (as the example workflow does).