### PR TITLE
Fix snapshot-hash

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -163,7 +163,11 @@ runs:
         echo "${{ inputs.working-directory }}/.stack-work" >>"$GITHUB_OUTPUT"
         echo 'EOM' >>"$GITHUB_OUTPUT"
 
-        echo "snapshot-hash=${{ hashFiles(inputs.stack-yaml) }}" >>"$GITHUB_OUTPUT"
+        # NB. hashFiles() is VERY PICKY. We need to account for
+        # working-directory manually like this or it considers the stack-yaml
+        # not under the workspace. And it ignores files not under the workspace,
+        # silently producing an empty hash.
+        echo "snapshot-hash=${{ hashFiles(format('{0}/{1}', inputs.working-directory, inputs.stack-yaml)) }}" >>"$GITHUB_OUTPUT"
         echo "package-hash=${{ hashFiles('**/package.yaml', '**/*.cabal') }}" >>"$GITHUB_OUTPUT"
         echo "sources-hash=${{ hashFiles('**', '!**/.stack-work') }}" >>"$GITHUB_OUTPUT"
 

--- a/action.yml
+++ b/action.yml
@@ -226,7 +226,7 @@ runs:
       uses: actions/cache/save@v3
       with:
         path: ${{ steps.setup.outputs.stack-works }}
-        key: ${{ inputs.cache-prefix }}${{ runner.os }}-stack-build-${{ steps.setup.outputs.package-hash }}-${{ steps.setup.outputs.sources-hash }}
+        key: ${{ inputs.cache-prefix }}${{ runner.os }}-stack-build-${{ steps.setup.outputs.snapshot-hash }}-${{ steps.setup.outputs.package-hash }}-${{ steps.setup.outputs.sources-hash }}
 
     - name: Test
       if: ${{ inputs.test == 'true' }}


### PR DESCRIPTION
`hashFiles()` ignores any files not under the current workspace. Unclear
why, maybe it's a security thing. This made it ignore given file and
silently produce an empty hash. Well done. Making the path relative to
the workspace (by accounting for `working-directory`) gets it working.