### PR TITLE
Determine top-level .stack-work for caching by stack-yaml location

### DIFF
--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -75,8 +75,6 @@ jobs:
           [[ -n "${{ steps.stack.outputs.local-install-root }}" ]]
           [[ -n "${{ steps.stack.outputs.dist-dir }}" ]]
           [[ -n "${{ steps.stack.outputs.local-hpc-root }}" ]]
-          [[ -n "${{ steps.stack.outputs.local-bin-path }}" ]]
-          [[ -n "${{ steps.stack.outputs.ghc-paths }}" ]]
 
   test-auto-nightly:
     runs-on: ubuntu-latest

--- a/action.yml
+++ b/action.yml
@@ -101,12 +101,6 @@ outputs:
   local-hpc-root:
     description: "local-hpc-root value from stack path"
     value: ${{ steps.stack-path.outputs.local-hpc-root }}
-  local-bin-path:
-    description: "local-bin-path value from stack path"
-    value: ${{ steps.stack-path.outputs.local-bin-path }}
-  ghc-paths:
-    description: "ghc-paths value from stack path"
-    value: ${{ steps.stack-path.outputs.ghc-paths }}
 runs:
   using: composite
   steps:

--- a/action.yml
+++ b/action.yml
@@ -161,7 +161,7 @@ runs:
 
         # Always include a top-level .stack-work, with the location being driven
         # by the stack-yaml directory.
-        echo "$(dirname ${{ format('{0}/{1}', inputs.working-directory, inputs.stack-yaml) }})/.stack-work" >>"$GITHUB_OUTPUT"
+        echo "$(dirname '${{ format('{0}/{1}', inputs.working-directory, inputs.stack-yaml) }}')/.stack-work" >>"$GITHUB_OUTPUT"
         echo 'EOM' >>"$GITHUB_OUTPUT"
 
         # NB. hashFiles() is VERY PICKY. We need to account for

--- a/action.yml
+++ b/action.yml
@@ -159,8 +159,9 @@ runs:
             fi
           done | sort -u >>"$GITHUB_OUTPUT"
 
-        # Always include a top-level .stack-work
-        echo "${{ inputs.working-directory }}/.stack-work" >>"$GITHUB_OUTPUT"
+        # Always include a top-level .stack-work, with the location being driven
+        # by the stack-yaml directory.
+        echo "$(dirname ${{ format('{0}/{1}', inputs.working-directory, inputs.stack-yaml) }})/.stack-work" >>"$GITHUB_OUTPUT"
         echo 'EOM' >>"$GITHUB_OUTPUT"
 
         # NB. hashFiles() is VERY PICKY. We need to account for


### PR DESCRIPTION
This PR updates the top-level `.stack-work` that gets included in the cache such that it's the `.stack-work` rooted under the directory containing the `stack-yaml`.

With a project like this, where the user has slotted their stack yaml files for CI under a `stack/` folder:

```
* foo/
  * stack/
    * stack-nightly.yaml
    * ...
```

If the user builds the `foo` project with `stack-yaml=stack/stack-nightly.yaml` for example, the "top-level" `.stack-work` directory will be at `foo/stack/.stack-work` and not `foo/.stack-work`. With this PR's changes, the action will correctly pick the `.stack-work` location based upon `working-directory` + `stack-yaml` location.