### PR TITLE
docs(README): fix `outputs` indent

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,8 +127,8 @@ jobs:
       - uses: actions/checkout@v3
       - id: generate
         uses: freckle/stack-action/generate-matrix@v4
-  outputs:
-    stack-yamls: ${{ steps.generate.outputs.stack-yamls }}
+    outputs:
+      stack-yamls: ${{ steps.generate.outputs.stack-yamls }}
 
   test:
     needs: generate


### PR DESCRIPTION
The `output` should be present within each item of `jobs`. If this is missing,
the following errors will occur.

```
test.yml    14   3 error    0      Missing property "runs-on". (lsp)
test.yml    15   5 error    0      Property stack-yamls is not allowed. (lsp)
```