### PR TITLE
Allow a cache restore when stack.yaml changes

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -191,6 +191,7 @@ runs:
         key: ${{ inputs.cache-prefix }}${{ runner.os }}-stack-deps-${{ steps.stack-query.outputs.compiler }}-${{ steps.setup.outputs.snapshot-hash }}-${{ steps.setup.outputs.package-hash }}
         restore-keys: |
           ${{ inputs.cache-prefix }}${{ runner.os }}-stack-deps-${{ steps.stack-query.outputs.compiler }}-${{ steps.setup.outputs.snapshot-hash }}-
+          ${{ inputs.cache-prefix }}${{ runner.os }}-stack-deps-${{ steps.stack-query.outputs.compiler }}-
 
     - name: Dependencies
       if: steps.restore-deps.outputs.cache-hit != 'true'

--- a/action.yml
+++ b/action.yml
@@ -166,6 +166,21 @@ runs:
         echo "package-hash=${{ hashFiles('**/package.yaml', '**/*.cabal') }}" >>"$GITHUB_OUTPUT"
         echo "sources-hash=${{ hashFiles('**', '!**/.stack-work') }}" >>"$GITHUB_OUTPUT"
 
+    - id: stack-query
+      name: Set stack-query outputs
+      working-directory: ${{ inputs.working-directory }}
+      shell: bash
+      run: |
+        tmp=$(mktemp)
+        trap 'rm -r "$tmp"' EXIT
+
+        stack --no-terminal --stack-yaml ${{ inputs.stack-yaml }} \
+          ${{ steps.setup.outputs.resolver-nightly }} \
+          query compiler | tee "$tmp"
+
+        sed '/^actual: \(.*\)$/!d; s//compiler=\1/' "$tmp" >>"$GITHUB_OUTPUT"
+        sed '/^actual: ghc-\(.*\)$/!d; s//compiler-version=\1/' "$tmp" >>"$GITHUB_OUTPUT"
+
     - name: Restore dependencies cache
       id: restore-deps
       uses: actions/cache/restore@v3
@@ -236,21 +251,6 @@ runs:
           ${{ steps.setup.outputs.resolver-nightly }} \
           build ${{ steps.setup.outputs.stack-build-arguments }} --test \
           ${{ inputs.stack-arguments }}
-
-    - id: stack-query
-      name: Set stack-query outputs
-      working-directory: ${{ inputs.working-directory }}
-      shell: bash
-      run: |
-        tmp=$(mktemp)
-        trap 'rm -r "$tmp"' EXIT
-
-        stack --no-terminal --stack-yaml ${{ inputs.stack-yaml }} \
-          ${{ steps.setup.outputs.resolver-nightly }} \
-          query compiler | tee "$tmp"
-
-        sed '/^actual: \(.*\)$/!d; s//compiler=\1/' "$tmp" >>"$GITHUB_OUTPUT"
-        sed '/^actual: ghc-\(.*\)$/!d; s//compiler-version=\1/' "$tmp" >>"$GITHUB_OUTPUT"
 
     - id: stack-path
       name: Set stack-path outputs

--- a/action.yml
+++ b/action.yml
@@ -188,9 +188,9 @@ runs:
         path: |
           ~/.stack
           ${{ steps.setup.outputs.stack-works }}
-        key: ${{ inputs.cache-prefix }}${{ runner.os }}-stack-deps-${{ steps.setup.outputs.snapshot-hash }}-${{ steps.setup.outputs.package-hash }}
+        key: ${{ inputs.cache-prefix }}${{ runner.os }}-stack-deps-${{ steps.stack-query.outputs.compiler }}-${{ steps.setup.outputs.snapshot-hash }}-${{ steps.setup.outputs.package-hash }}
         restore-keys: |
-          ${{ inputs.cache-prefix }}${{ runner.os }}-stack-deps-${{ steps.setup.outputs.snapshot-hash }}-
+          ${{ inputs.cache-prefix }}${{ runner.os }}-stack-deps-${{ steps.stack-query.outputs.compiler }}-${{ steps.setup.outputs.snapshot-hash }}-
 
     - name: Dependencies
       if: steps.restore-deps.outputs.cache-hit != 'true'
@@ -212,7 +212,7 @@ runs:
         path: |
           ~/.stack
           ${{ steps.setup.outputs.stack-works }}
-        key: ${{ inputs.cache-prefix }}${{ runner.os }}-stack-deps-${{ steps.setup.outputs.snapshot-hash }}-${{ steps.setup.outputs.package-hash }}
+        key: ${{ inputs.cache-prefix }}${{ runner.os }}-stack-deps-${{ steps.stack-query.outputs.compiler }}-${{ steps.setup.outputs.snapshot-hash }}-${{ steps.setup.outputs.package-hash }}
 
     - name: Restore build cache
       id: restore-build


### PR DESCRIPTION
Using the `stack.yaml` contents as the sole cache key for dependencies makes sense when the vast majority of changes to `stack.yaml` are resolver upgrades that are going to necessitate rebuilding everything. It makes less sense when we're changing `stack.yaml` just to do an upgrade of a single dependency. For that sort of change, CI can make use of a previous cached dependency set and save (in the case of megarepo/backend) around an hour of rebuilding.

This change allows a build to restore any dependency cache that is for the same GHC version.