### PR TITLE
Fix deps cache path on Windows runners

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -181,23 +181,25 @@ runs:
         sed '/^actual: \(.*\)$/!d; s//compiler=\1/' "$tmp" >>"$GITHUB_OUTPUT"
         sed '/^actual: ghc-\(.*\)$/!d; s//compiler-version=\1/' "$tmp" >>"$GITHUB_OUTPUT"
 
-    - id: get-stack-root
-      name: Set stack-root output
+    - id: stack-path
+      name: Set stack-path outputs
       working-directory: ${{ inputs.working-directory }}
       shell: bash
       run: |
-        echo "stack-root=$(
-          stack --no-terminal --stack-yaml ${{ inputs.stack-yaml }} \
-            ${{ steps.setup.outputs.resolver-nightly }} \
-            path --stack-root
-        )" >>"$GITHUB_OUTPUT"
+        stack --no-terminal --stack-yaml ${{ inputs.stack-yaml }} \
+          ${{ steps.setup.outputs.resolver-nightly }} \
+          path | while IFS=:\  read -r name value; do
+          printf '%s: %s\n' "$name" "$value"
+          printf '%s=%s\n' "$name" "$value" >>"$GITHUB_OUTPUT"
+        done
 
     - name: Restore dependencies cache
       id: restore-deps
       uses: actions/cache/restore@v3
       with:
         path: |
-          ${{ steps.get-stack-root.outputs.stack-root }}
+          ${{ steps.stack-path.outputs.stack-root }}
+          ${{ steps.stack-path.outputs.programs }}
           ${{ steps.setup.outputs.stack-works }}
         key: ${{ inputs.cache-prefix }}${{ runner.os }}-stack-deps-${{ steps.stack-query.outputs.compiler }}-${{ steps.setup.outputs.snapshot-hash }}-${{ steps.setup.outputs.package-hash }}
         restore-keys: |
@@ -222,7 +224,8 @@ runs:
       uses: actions/cache/save@v3
       with:
         path: |
-          ${{ steps.get-stack-root.outputs.stack-root }}
+          ${{ steps.stack-path.outputs.stack-root }}
+          ${{ steps.stack-path.outputs.programs }}
           ${{ steps.setup.outputs.stack-works }}
         key: ${{ inputs.cache-prefix }}${{ runner.os }}-stack-deps-${{ steps.stack-query.outputs.compiler }}-${{ steps.setup.outputs.snapshot-hash }}-${{ steps.setup.outputs.package-hash }}
 
@@ -263,15 +266,3 @@ runs:
           ${{ steps.setup.outputs.resolver-nightly }} \
           build ${{ steps.setup.outputs.stack-build-arguments }} --test \
           ${{ inputs.stack-arguments }}
-
-    - id: stack-path
-      name: Set stack-path outputs
-      working-directory: ${{ inputs.working-directory }}
-      shell: bash
-      run: |
-        stack --no-terminal --stack-yaml ${{ inputs.stack-yaml }} \
-          ${{ steps.setup.outputs.resolver-nightly }} \
-          path | while IFS=:\  read -r name value; do
-          printf '%s: %s\n' "$name" "$value"
-          printf '%s=%s\n' "$name" "$value" >>"$GITHUB_OUTPUT"
-        done

--- a/action.yml
+++ b/action.yml
@@ -181,17 +181,23 @@ runs:
         sed '/^actual: \(.*\)$/!d; s//compiler=\1/' "$tmp" >>"$GITHUB_OUTPUT"
         sed '/^actual: ghc-\(.*\)$/!d; s//compiler-version=\1/' "$tmp" >>"$GITHUB_OUTPUT"
 
+    - id: get-stack-root
+      name: Set stack-root output
+      working-directory: ${{ inputs.working-directory }}
+      shell: bash
+      run: |
+        echo "stack-root='$(
+          stack --no-terminal --stack-yaml ${{ inputs.stack-yaml }} \
+            ${{ steps.setup.outputs.resolver-nightly }} \
+            path --stack-root
+        )'" >>"$GITHUB_OUTPUT"
+
     - name: Restore dependencies cache
       id: restore-deps
       uses: actions/cache/restore@v3
       with:
         path: |
-          ${{ startsWith(runner.os, 'Windows') && 
-              '
-              ~\AppData\Roaming\stack
-              ~\AppData\Local\Programs\stack'
-            || '~/.stack'
-          }}
+          ${{ steps.get-stack-root.outputs.stack-root }}
           ${{ steps.setup.outputs.stack-works }}
         key: ${{ inputs.cache-prefix }}${{ runner.os }}-stack-deps-${{ steps.stack-query.outputs.compiler }}-${{ steps.setup.outputs.snapshot-hash }}-${{ steps.setup.outputs.package-hash }}
         restore-keys: |
@@ -216,12 +222,7 @@ runs:
       uses: actions/cache/save@v3
       with:
         path: |
-          ${{ startsWith(runner.os, 'Windows') && 
-              '
-              ~\AppData\Roaming\stack
-              ~\AppData\Local\Programs\stack'
-            || '~/.stack'
-          }}
+          ${{ steps.get-stack-root.outputs.stack-root }}
           ${{ steps.setup.outputs.stack-works }}
         key: ${{ inputs.cache-prefix }}${{ runner.os }}-stack-deps-${{ steps.stack-query.outputs.compiler }}-${{ steps.setup.outputs.snapshot-hash }}-${{ steps.setup.outputs.package-hash }}
 

--- a/action.yml
+++ b/action.yml
@@ -186,11 +186,11 @@ runs:
       working-directory: ${{ inputs.working-directory }}
       shell: bash
       run: |
-        echo "stack-root='$(
+        echo "stack-root=$(
           stack --no-terminal --stack-yaml ${{ inputs.stack-yaml }} \
             ${{ steps.setup.outputs.resolver-nightly }} \
             path --stack-root
-        )'" >>"$GITHUB_OUTPUT"
+        )" >>"$GITHUB_OUTPUT"
 
     - name: Restore dependencies cache
       id: restore-deps

--- a/action.yml
+++ b/action.yml
@@ -186,7 +186,12 @@ runs:
       uses: actions/cache/restore@v3
       with:
         path: |
-          ~/.stack
+          ${{ startsWith(runner.os, 'Windows') && 
+              '
+              ~\AppData\Roaming\stack
+              ~\AppData\Local\Programs\stack'
+            || '~/.stack'
+          }}
           ${{ steps.setup.outputs.stack-works }}
         key: ${{ inputs.cache-prefix }}${{ runner.os }}-stack-deps-${{ steps.stack-query.outputs.compiler }}-${{ steps.setup.outputs.snapshot-hash }}-${{ steps.setup.outputs.package-hash }}
         restore-keys: |
@@ -211,7 +216,12 @@ runs:
       uses: actions/cache/save@v3
       with:
         path: |
-          ~/.stack
+          ${{ startsWith(runner.os, 'Windows') && 
+              '
+              ~\AppData\Roaming\stack
+              ~\AppData\Local\Programs\stack'
+            || '~/.stack'
+          }}
           ${{ steps.setup.outputs.stack-works }}
         key: ${{ inputs.cache-prefix }}${{ runner.os }}-stack-deps-${{ steps.stack-query.outputs.compiler }}-${{ steps.setup.outputs.snapshot-hash }}-${{ steps.setup.outputs.package-hash }}
 


### PR DESCRIPTION
Closes #30. Now, the action saves and restores a cache on Windows.

[Save](https://github.com/deemp/stack-action/actions/runs/7461257522/job/20301007489#step:3:251)

```console
2024-01-09T12:42:09.6413742Z ##[group]Run actions/cache/save@v3
2024-01-09T12:42:09.6414056Z with:
2024-01-09T12:42:09.6414548Z   path: 
    ~\AppData\Roaming\stack
    ~\AppData\Local\Programs\stack
example/.stack-work

2024-01-09T12:42:09.6415902Z   key: lts-18.28/Windows-stack-deps-ghc-8.10.4-c5bbcfeb57fc0248fc97821db760be9c748b2f6a1b66ff669c9033d4703a1745-97cca0be4f1fb86cacd6e83343618ff132edd2e2876d42b683671bbb71fdd728
2024-01-09T12:42:09.6417034Z   enableCrossOsArchive: false
2024-01-09T12:42:09.6417316Z ##[endgroup]
2024-01-09T12:42:09.8756874Z [command]"C:\Program Files\Git\usr\bin\tar.exe" --posix -cf cache.tzst --exclude cache.tzst -P -C D:/a/stack-action/stack-action --files-from manifest.txt --force-local --use-compress-program "zstd -T0"
2024-01-09T12:43:15.8787733Z Cache Size: ~1821 MB (1909829439 B)
2024-01-09T12:43:16.0049035Z Cache saved successfully
2024-01-09T12:43:16.0973632Z Cache saved with key: lts-18.28/Windows-stack-deps-ghc-8.10.4-c5bbcfeb57fc0248fc97821db760be9c748b2f6a1b66ff669c9033d4703a1745-97cca0be4f1fb86cacd6e83343618ff132edd2e2876d42b683671bbb71fdd728
```

[Restore](https://github.com/deemp/stack-action/actions/runs/7461343951/job/20301256701#step:3:206)

```console
2024-01-09T12:47:01.2851899Z ##[group]Run actions/cache/restore@v3
2024-01-09T12:47:01.2852225Z with:
2024-01-09T12:47:01.2852703Z   path: 
    ~\AppData\Roaming\stack
    ~\AppData\Local\Programs\stack
example/.stack-work

2024-01-09T12:47:01.2853981Z   key: lts-18.28/Windows-stack-deps-ghc-8.10.4-c5bbcfeb57fc0248fc97821db760be9c748b2f6a1b66ff669c9033d4703a1745-97cca0be4f1fb86cacd6e83343618ff132edd2e2876d42b683671bbb71fdd728
2024-01-09T12:47:01.2855609Z   restore-keys: lts-18.28/Windows-stack-deps-ghc-8.10.4-c5bbcfeb57fc0248fc97821db760be9c748b2f6a1b66ff669c9033d4703a1745-
lts-18.28/Windows-stack-deps-ghc-8.10.4-

2024-01-09T12:47:01.2856523Z   enableCrossOsArchive: false
2024-01-09T12:47:01.2856818Z   fail-on-cache-miss: false
2024-01-09T12:47:01.2857086Z   lookup-only: false
2024-01-09T12:47:01.2857319Z ##[endgroup]
2024-01-09T12:47:03.3345270Z Received 0 of 1909829439 (0.0%), 0.0 MBs/sec
2024-01-09T12:47:04.3439574Z Received 104857600 of 1909829439 (5.5%), 49.7 MBs/sec
2024-01-09T12:47:05.3482034Z Received 209715200 of 1909829439 (11.0%), 66.3 MBs/sec
2024-01-09T12:47:06.3494031Z Received 310378496 of 1909829439 (16.3%), 73.7 MBs/sec
2024-01-09T12:47:07.3485392Z Received 406847488 of 1909829439 (21.3%), 77.4 MBs/sec
2024-01-09T12:47:08.3624659Z Received 507510784 of 1909829439 (26.6%), 80.3 MBs/sec
2024-01-09T12:47:09.3626849Z Received 624951296 of 1909829439 (32.7%), 84.8 MBs/sec
2024-01-09T12:47:10.3628625Z Received 725614592 of 1909829439 (38.0%), 86.2 MBs/sec
2024-01-09T12:47:11.3638576Z Received 834666496 of 1909829439 (43.7%), 88.1 MBs/sec
2024-01-09T12:47:12.3677604Z Received 935329792 of 1909829439 (49.0%), 88.9 MBs/sec
2024-01-09T12:47:13.3747019Z Received 1027604480 of 1909829439 (53.8%), 88.8 MBs/sec
2024-01-09T12:47:14.3749072Z Received 1124073472 of 1909829439 (58.9%), 89.0 MBs/sec
2024-01-09T12:47:15.3755437Z Received 1224736768 of 1909829439 (64.1%), 89.5 MBs/sec
2024-01-09T12:47:16.3780945Z Received 1329594368 of 1909829439 (69.6%), 90.3 MBs/sec
2024-01-09T12:47:17.3798642Z Received 1438646272 of 1909829439 (75.3%), 91.2 MBs/sec
2024-01-09T12:47:18.3822041Z Received 1539309568 of 1909829439 (80.6%), 91.5 MBs/sec
2024-01-09T12:47:19.3850113Z Received 1635778560 of 1909829439 (85.7%), 91.5 MBs/sec
2024-01-09T12:47:20.3917792Z Received 1740636160 of 1909829439 (91.1%), 91.9 MBs/sec
2024-01-09T12:47:21.3959909Z Received 1849688064 of 1909829439 (96.9%), 92.5 MBs/sec
2024-01-09T12:47:22.0065024Z Cache Size: ~1821 MB (1909829439 B)
2024-01-09T12:47:22.0119898Z [command]"C:\Program Files\Git\usr\bin\tar.exe" -xf D:/a/_temp/7094c615-ea39-49d6-9822-993ade67f36d/cache.tzst -P -C D:/a/stack-action/stack-action --force-local --use-compress-program "zstd -d"
2024-01-09T12:47:22.3968092Z Received 1909829439 of 1909829439 (100.0%), 90.8 MBs/sec
2024-01-09T12:48:40.0021900Z Cache restored successfully
2024-01-09T12:48:41.2579772Z Cache restored from key: lts-18.28/Windows-stack-deps-ghc-8.10.4-c5bbcfeb57fc0248fc97821db760be9c748b2f6a1b66ff669c9033d4703a1745-97cca0be4f1fb86cacd6e83343618ff132edd2e2876d42b683671bbb71fdd728
```