### PR TITLE
Add `inputs.cache-save-always`

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ need to use a separate `stack-cache-action` step any more.
   explicitly bust caches. The default is empty.
 
 - `cache-save-always`: save artifacts to the cache even if the build fails.
-  This may speed up builds in subsequent runs.
+  This may speed up builds in subsequent runs at the expense of slightly-longer
+  builds when a full cache-hit occurs. (Since `@v4.2.0`)
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ need to use a separate `stack-cache-action` step any more.
   like, but teams often use `v{N}` and bump it to `v{N+1}` when/if they need to
   explicitly bust caches. The default is empty.
 
+- `cache-save-always`: save artifacts to the cache even if the build fails.
+  This may speed up builds in subsequent runs.
+
 ## Outputs
 
 `compiler` (e.g. `ghc-9.2.5`) and `compiler-version` (e.g. `9.2.5`) are set from

--- a/action.yml
+++ b/action.yml
@@ -221,7 +221,7 @@ runs:
           ${{ inputs.stack-arguments }}
 
     - name: Save dependencies cache
-      if: success() || (failure() && inputs.cache-save-always)
+      if: success() || (failure() && inputs.cache-save-always == 'true')
       uses: actions/cache/save@v3
       with:
         path: |
@@ -250,7 +250,7 @@ runs:
           ${{ inputs.stack-arguments }}
 
     - name: Save build cache
-      if: success() || (failure() && inputs.cache-save-always)
+      if: success() || (failure() && inputs.cache-save-always == 'true')
       uses: actions/cache/save@v3
       with:
         path: ${{ steps.setup.outputs.stack-works }}

--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,9 @@ inputs:
   cache-prefix:
     required: true
     default: ""
+  cache-save-always:
+    description: "Save the dependencies and build cache even if a build fails"
+    default: false
 outputs:
   compiler:
     description: "compiler.actual value from stack query"
@@ -194,7 +197,6 @@ runs:
         done
 
     - name: Restore dependencies cache
-      id: restore-deps
       uses: actions/cache/restore@v3
       with:
         path: |
@@ -207,7 +209,6 @@ runs:
           ${{ inputs.cache-prefix }}${{ runner.os }}-stack-deps-${{ steps.stack-query.outputs.compiler }}-
 
     - name: Dependencies
-      if: steps.restore-deps.outputs.cache-hit != 'true'
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: |
@@ -220,7 +221,7 @@ runs:
           ${{ inputs.stack-arguments }}
 
     - name: Save dependencies cache
-      if: steps.restore-deps.outputs.cache-hit != 'true'
+      if: success() || (failure() && inputs.cache-save-always)
       uses: actions/cache/save@v3
       with:
         path: |
@@ -230,7 +231,6 @@ runs:
         key: ${{ inputs.cache-prefix }}${{ runner.os }}-stack-deps-${{ steps.stack-query.outputs.compiler }}-${{ steps.setup.outputs.snapshot-hash }}-${{ steps.setup.outputs.package-hash }}
 
     - name: Restore build cache
-      id: restore-build
       uses: actions/cache/restore@v3
       with:
         path: ${{ steps.setup.outputs.stack-works }}
@@ -240,7 +240,6 @@ runs:
           ${{ inputs.cache-prefix }}${{ runner.os }}-stack-build-${{ steps.setup.outputs.snapshot-hash }}-
 
     - name: Build
-      if: steps.restore-build.outputs.cache-hit != 'true'
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: |
@@ -251,7 +250,7 @@ runs:
           ${{ inputs.stack-arguments }}
 
     - name: Save build cache
-      if: steps.restore-build.outputs.cache-hit != 'true'
+      if: success() || (failure() && inputs.cache-save-always)
       uses: actions/cache/save@v3
       with:
         path: ${{ steps.setup.outputs.stack-works }}

--- a/action.yml
+++ b/action.yml
@@ -197,6 +197,7 @@ runs:
         done
 
     - name: Restore dependencies cache
+      id: restore-deps
       uses: actions/cache/restore@v3
       with:
         path: |
@@ -205,10 +206,12 @@ runs:
           ${{ steps.setup.outputs.stack-works }}
         key: ${{ inputs.cache-prefix }}${{ runner.os }}-stack-deps-${{ steps.stack-query.outputs.compiler }}-${{ steps.setup.outputs.snapshot-hash }}-${{ steps.setup.outputs.package-hash }}
         restore-keys: |
+          ${{ inputs.cache-prefix }}${{ runner.os }}-stack-deps-${{ steps.stack-query.outputs.compiler }}-${{ steps.setup.outputs.snapshot-hash }}-${{ steps.setup.outputs.package-hash }}-partial
           ${{ inputs.cache-prefix }}${{ runner.os }}-stack-deps-${{ steps.stack-query.outputs.compiler }}-${{ steps.setup.outputs.snapshot-hash }}-
           ${{ inputs.cache-prefix }}${{ runner.os }}-stack-deps-${{ steps.stack-query.outputs.compiler }}-
 
     - name: Dependencies
+      if: steps.restore-deps.outputs.cache-hit != 'true'
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: |
@@ -221,25 +224,30 @@ runs:
           ${{ inputs.stack-arguments }}
 
     - name: Save dependencies cache
-      if: success() || (failure() && inputs.cache-save-always == 'true')
+      if: |
+        (success() && steps.restore-deps.outputs.cache-hit != 'true') ||
+        (failure() && inputs.cache-save-always == 'true')
       uses: actions/cache/save@v3
       with:
         path: |
           ${{ steps.stack-path.outputs.stack-root }}
           ${{ steps.stack-path.outputs.programs }}
           ${{ steps.setup.outputs.stack-works }}
-        key: ${{ inputs.cache-prefix }}${{ runner.os }}-stack-deps-${{ steps.stack-query.outputs.compiler }}-${{ steps.setup.outputs.snapshot-hash }}-${{ steps.setup.outputs.package-hash }}
+        key: ${{ inputs.cache-prefix }}${{ runner.os }}-stack-deps-${{ steps.stack-query.outputs.compiler }}-${{ steps.setup.outputs.snapshot-hash }}-${{ steps.setup.outputs.package-hash }}${{ failure() && '-partial' }}
 
     - name: Restore build cache
+      id: restore-build
       uses: actions/cache/restore@v3
       with:
         path: ${{ steps.setup.outputs.stack-works }}
         key: ${{ inputs.cache-prefix }}${{ runner.os }}-stack-build-${{ steps.setup.outputs.snapshot-hash }}-${{ steps.setup.outputs.package-hash }}-${{ steps.setup.outputs.sources-hash }}
         restore-keys: |
+          ${{ inputs.cache-prefix }}${{ runner.os }}-stack-build-${{ steps.setup.outputs.snapshot-hash }}-${{ steps.setup.outputs.package-hash }}-${{ steps.setup.outputs.sources-hash }}-partial
           ${{ inputs.cache-prefix }}${{ runner.os }}-stack-build-${{ steps.setup.outputs.snapshot-hash }}-${{ steps.setup.outputs.package-hash }}-
           ${{ inputs.cache-prefix }}${{ runner.os }}-stack-build-${{ steps.setup.outputs.snapshot-hash }}-
 
     - name: Build
+      if: steps.restore-build.outputs.cache-hit != 'true'
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: |
@@ -250,11 +258,13 @@ runs:
           ${{ inputs.stack-arguments }}
 
     - name: Save build cache
-      if: success() || (failure() && inputs.cache-save-always == 'true')
+      if: |
+        (success() && steps.restore-deps.outputs.cache-hit != 'true') ||
+        (failure() && inputs.cache-save-always == 'true')
       uses: actions/cache/save@v3
       with:
         path: ${{ steps.setup.outputs.stack-works }}
-        key: ${{ inputs.cache-prefix }}${{ runner.os }}-stack-build-${{ steps.setup.outputs.snapshot-hash }}-${{ steps.setup.outputs.package-hash }}-${{ steps.setup.outputs.sources-hash }}
+        key: ${{ inputs.cache-prefix }}${{ runner.os }}-stack-build-${{ steps.setup.outputs.snapshot-hash }}-${{ steps.setup.outputs.package-hash }}-${{ steps.setup.outputs.sources-hash }}${{ failure() && '-partial' }}
 
     - name: Test
       if: ${{ inputs.test == 'true' }}

--- a/action.yml
+++ b/action.yml
@@ -223,12 +223,6 @@ runs:
           build --dependencies-only --test --no-run-tests \
           ${{ inputs.stack-arguments }}
 
-    - name: Set dependencies cache key suffix on failure
-      id: deps-cache-key
-      if: failure() && inputs.cache-save-always == 'true'
-      shell: bash
-      run: echo "suffix=-partial" >>"$GITHUB_OUTPUT"
-
     - name: Save dependencies cache
       if: |
         (success() && steps.restore-deps.outputs.cache-hit != 'true') ||
@@ -239,7 +233,7 @@ runs:
           ${{ steps.stack-path.outputs.stack-root }}
           ${{ steps.stack-path.outputs.programs }}
           ${{ steps.setup.outputs.stack-works }}
-        key: ${{ inputs.cache-prefix }}${{ runner.os }}-stack-deps-${{ steps.stack-query.outputs.compiler }}-${{ steps.setup.outputs.snapshot-hash }}-${{ steps.setup.outputs.package-hash }}${{ steps.deps-cache-key.outputs.suffix }}
+        key: ${{ inputs.cache-prefix }}${{ runner.os }}-stack-deps-${{ steps.stack-query.outputs.compiler }}-${{ steps.setup.outputs.snapshot-hash }}-${{ steps.setup.outputs.package-hash }}${{ failure() && '-partial' }}
 
     - name: Restore build cache
       id: restore-build
@@ -263,12 +257,6 @@ runs:
           --test --no-run-tests \
           ${{ inputs.stack-arguments }}
 
-    - name: Set build cache key suffix on failure
-      id: build-cache-key
-      if: failure() && inputs.cache-save-always == 'true'
-      shell: bash
-      run: echo "suffix=-partial" >>"$GITHUB_OUTPUT"
-
     - name: Save build cache
       if: |
         (success() && steps.restore-deps.outputs.cache-hit != 'true') ||
@@ -276,7 +264,7 @@ runs:
       uses: actions/cache/save@v3
       with:
         path: ${{ steps.setup.outputs.stack-works }}
-        key: ${{ inputs.cache-prefix }}${{ runner.os }}-stack-build-${{ steps.setup.outputs.snapshot-hash }}-${{ steps.setup.outputs.package-hash }}-${{ steps.setup.outputs.sources-hash }}${{ steps.build-cache-key.outputs.suffix }}
+        key: ${{ inputs.cache-prefix }}${{ runner.os }}-stack-build-${{ steps.setup.outputs.snapshot-hash }}-${{ steps.setup.outputs.package-hash }}-${{ steps.setup.outputs.sources-hash }}${{ failure() && '-partial' }}
 
     - name: Test
       if: ${{ inputs.test == 'true' }}

--- a/action.yml
+++ b/action.yml
@@ -197,6 +197,7 @@ runs:
         done
 
     - name: Restore dependencies cache
+      id: restore-deps
       uses: actions/cache/restore@v3
       with:
         path: |
@@ -209,6 +210,9 @@ runs:
           ${{ inputs.cache-prefix }}${{ runner.os }}-stack-deps-${{ steps.stack-query.outputs.compiler }}-
 
     - name: Dependencies
+      if: |
+        (success() && steps.restore-deps.outputs.cache-hit != 'true') ||
+        (!cancelled() && inputs.cache-save-always == 'true')
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: |
@@ -221,7 +225,9 @@ runs:
           ${{ inputs.stack-arguments }}
 
     - name: Save dependencies cache
-      if: success() || (failure() && inputs.cache-save-always == 'true')
+      if: |
+        (success() && steps.restore-deps.outputs.cache-hit != 'true') ||
+        (!cancelled() && inputs.cache-save-always == 'true')
       uses: actions/cache/save@v3
       with:
         path: |
@@ -231,6 +237,7 @@ runs:
         key: ${{ inputs.cache-prefix }}${{ runner.os }}-stack-deps-${{ steps.stack-query.outputs.compiler }}-${{ steps.setup.outputs.snapshot-hash }}-${{ steps.setup.outputs.package-hash }}
 
     - name: Restore build cache
+      id: restore-build
       uses: actions/cache/restore@v3
       with:
         path: ${{ steps.setup.outputs.stack-works }}
@@ -240,6 +247,9 @@ runs:
           ${{ inputs.cache-prefix }}${{ runner.os }}-stack-build-${{ steps.setup.outputs.snapshot-hash }}-
 
     - name: Build
+      if: |
+        (success() && steps.restore-build.outputs.cache-hit != 'true') ||
+        (!cancelled() && inputs.cache-save-always == 'true')
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: |
@@ -250,7 +260,9 @@ runs:
           ${{ inputs.stack-arguments }}
 
     - name: Save build cache
-      if: success() || (failure() && inputs.cache-save-always == 'true')
+      if: |
+        (success() && steps.restore-build.outputs.cache-hit != 'true') ||
+        (!cancelled() && inputs.cache-save-always == 'true')
       uses: actions/cache/save@v3
       with:
         path: ${{ steps.setup.outputs.stack-works }}

--- a/action.yml
+++ b/action.yml
@@ -197,7 +197,6 @@ runs:
         done
 
     - name: Restore dependencies cache
-      id: restore-deps
       uses: actions/cache/restore@v3
       with:
         path: |
@@ -206,12 +205,10 @@ runs:
           ${{ steps.setup.outputs.stack-works }}
         key: ${{ inputs.cache-prefix }}${{ runner.os }}-stack-deps-${{ steps.stack-query.outputs.compiler }}-${{ steps.setup.outputs.snapshot-hash }}-${{ steps.setup.outputs.package-hash }}
         restore-keys: |
-          ${{ inputs.cache-prefix }}${{ runner.os }}-stack-deps-${{ steps.stack-query.outputs.compiler }}-${{ steps.setup.outputs.snapshot-hash }}-${{ steps.setup.outputs.package-hash }}-partial
           ${{ inputs.cache-prefix }}${{ runner.os }}-stack-deps-${{ steps.stack-query.outputs.compiler }}-${{ steps.setup.outputs.snapshot-hash }}-
           ${{ inputs.cache-prefix }}${{ runner.os }}-stack-deps-${{ steps.stack-query.outputs.compiler }}-
 
     - name: Dependencies
-      if: steps.restore-deps.outputs.cache-hit != 'true'
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: |
@@ -224,30 +221,25 @@ runs:
           ${{ inputs.stack-arguments }}
 
     - name: Save dependencies cache
-      if: |
-        (success() && steps.restore-deps.outputs.cache-hit != 'true') ||
-        (failure() && inputs.cache-save-always == 'true')
+      if: success() || (failure() && inputs.cache-save-always == 'true')
       uses: actions/cache/save@v3
       with:
         path: |
           ${{ steps.stack-path.outputs.stack-root }}
           ${{ steps.stack-path.outputs.programs }}
           ${{ steps.setup.outputs.stack-works }}
-        key: ${{ inputs.cache-prefix }}${{ runner.os }}-stack-deps-${{ steps.stack-query.outputs.compiler }}-${{ steps.setup.outputs.snapshot-hash }}-${{ steps.setup.outputs.package-hash }}${{ failure() && '-partial' }}
+        key: ${{ inputs.cache-prefix }}${{ runner.os }}-stack-deps-${{ steps.stack-query.outputs.compiler }}-${{ steps.setup.outputs.snapshot-hash }}-${{ steps.setup.outputs.package-hash }}
 
     - name: Restore build cache
-      id: restore-build
       uses: actions/cache/restore@v3
       with:
         path: ${{ steps.setup.outputs.stack-works }}
         key: ${{ inputs.cache-prefix }}${{ runner.os }}-stack-build-${{ steps.setup.outputs.snapshot-hash }}-${{ steps.setup.outputs.package-hash }}-${{ steps.setup.outputs.sources-hash }}
         restore-keys: |
-          ${{ inputs.cache-prefix }}${{ runner.os }}-stack-build-${{ steps.setup.outputs.snapshot-hash }}-${{ steps.setup.outputs.package-hash }}-${{ steps.setup.outputs.sources-hash }}-partial
           ${{ inputs.cache-prefix }}${{ runner.os }}-stack-build-${{ steps.setup.outputs.snapshot-hash }}-${{ steps.setup.outputs.package-hash }}-
           ${{ inputs.cache-prefix }}${{ runner.os }}-stack-build-${{ steps.setup.outputs.snapshot-hash }}-
 
     - name: Build
-      if: steps.restore-build.outputs.cache-hit != 'true'
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: |
@@ -258,13 +250,11 @@ runs:
           ${{ inputs.stack-arguments }}
 
     - name: Save build cache
-      if: |
-        (success() && steps.restore-deps.outputs.cache-hit != 'true') ||
-        (failure() && inputs.cache-save-always == 'true')
+      if: success() || (failure() && inputs.cache-save-always == 'true')
       uses: actions/cache/save@v3
       with:
         path: ${{ steps.setup.outputs.stack-works }}
-        key: ${{ inputs.cache-prefix }}${{ runner.os }}-stack-build-${{ steps.setup.outputs.snapshot-hash }}-${{ steps.setup.outputs.package-hash }}-${{ steps.setup.outputs.sources-hash }}${{ failure() && '-partial' }}
+        key: ${{ inputs.cache-prefix }}${{ runner.os }}-stack-build-${{ steps.setup.outputs.snapshot-hash }}-${{ steps.setup.outputs.package-hash }}-${{ steps.setup.outputs.sources-hash }}
 
     - name: Test
       if: ${{ inputs.test == 'true' }}

--- a/action.yml
+++ b/action.yml
@@ -223,6 +223,12 @@ runs:
           build --dependencies-only --test --no-run-tests \
           ${{ inputs.stack-arguments }}
 
+    - name: Set dependencies cache key suffix on failure
+      id: deps-cache-key
+      if: failure() && inputs.cache-save-always == 'true'
+      shell: bash
+      run: echo "suffix=-partial" >>"$GITHUB_OUTPUT"
+
     - name: Save dependencies cache
       if: |
         (success() && steps.restore-deps.outputs.cache-hit != 'true') ||
@@ -233,7 +239,7 @@ runs:
           ${{ steps.stack-path.outputs.stack-root }}
           ${{ steps.stack-path.outputs.programs }}
           ${{ steps.setup.outputs.stack-works }}
-        key: ${{ inputs.cache-prefix }}${{ runner.os }}-stack-deps-${{ steps.stack-query.outputs.compiler }}-${{ steps.setup.outputs.snapshot-hash }}-${{ steps.setup.outputs.package-hash }}${{ failure() && '-partial' }}
+        key: ${{ inputs.cache-prefix }}${{ runner.os }}-stack-deps-${{ steps.stack-query.outputs.compiler }}-${{ steps.setup.outputs.snapshot-hash }}-${{ steps.setup.outputs.package-hash }}${{ steps.deps-cache-key.outputs.suffix }}
 
     - name: Restore build cache
       id: restore-build
@@ -257,6 +263,12 @@ runs:
           --test --no-run-tests \
           ${{ inputs.stack-arguments }}
 
+    - name: Set build cache key suffix on failure
+      id: build-cache-key
+      if: failure() && inputs.cache-save-always == 'true'
+      shell: bash
+      run: echo "suffix=-partial" >>"$GITHUB_OUTPUT"
+
     - name: Save build cache
       if: |
         (success() && steps.restore-deps.outputs.cache-hit != 'true') ||
@@ -264,7 +276,7 @@ runs:
       uses: actions/cache/save@v3
       with:
         path: ${{ steps.setup.outputs.stack-works }}
-        key: ${{ inputs.cache-prefix }}${{ runner.os }}-stack-build-${{ steps.setup.outputs.snapshot-hash }}-${{ steps.setup.outputs.package-hash }}-${{ steps.setup.outputs.sources-hash }}${{ failure() && '-partial' }}
+        key: ${{ inputs.cache-prefix }}${{ runner.os }}-stack-build-${{ steps.setup.outputs.snapshot-hash }}-${{ steps.setup.outputs.package-hash }}-${{ steps.setup.outputs.sources-hash }}${{ steps.build-cache-key.outputs.suffix }}
 
     - name: Test
       if: ${{ inputs.test == 'true' }}


### PR DESCRIPTION
Adds an input that borrows the `save-always` input from [v4 of `actions/cache`][0], which will run the post step to save the cache even if a failure occurs. Using the added `cache-save-always` input saves the cache when a build fails, which will speed up subsequent runs which restore the partial build. This comes at the cost of requiring a build when there is an exact `key` match, since the cache from a failed build will have the same `key` as a completed build.

[0]: https://github.com/actions/cache/tree/main#v4