### PR TITLE
Support more granular stack arguments

### DIFF
--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -24,7 +24,7 @@ jobs:
 
         stack:
           - resolver: nightly
-            ghc: "9.8.1"
+          - resolver: lts
           - resolver: lts-22.7
             ghc: "9.6.4"
           - resolver: lts-20.2
@@ -50,12 +50,15 @@ jobs:
           working-directory: example
           stack-arguments: --resolver ${{ matrix.stack.resolver }}
           cache-prefix: ${{ matrix.stack.resolver }}/
-
-      - shell: bash
+      
+      - if: matrix.stack.resolver != 'lts' && matrix.stack.resolver != 'nightly'
+        shell: bash
         run: |
           [[ "${{ steps.stack.outputs.compiler }}" = ghc-${{ matrix.stack.ghc }} ]]
           [[ "${{ steps.stack.outputs.compiler-version }}" = ${{ matrix.stack.ghc }} ]]
-
+      
+      - shell: bash
+        run: |
           # stack path | cut -d: -f1
           [[ -n "${{ steps.stack.outputs.snapshot-doc-root }}" ]]
           [[ -n "${{ steps.stack.outputs.local-doc-root }}" ]]

--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -53,7 +53,7 @@ jobs:
 
       - shell: bash
         run: |
-          [[ "${{ steps.stack.outputs.compiler }}" = ${{ format('ghc-{0}', matrix.stack.ghc) }} ]]
+          [[ "${{ steps.stack.outputs.compiler }}" = ghc-${{ matrix.stack.ghc }} ]]
           [[ "${{ steps.stack.outputs.compiler-version }}" = ${{ matrix.stack.ghc }} ]]
 
           # stack path | cut -d: -f1

--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -51,7 +51,7 @@ jobs:
           stack-arguments: --resolver ${{ matrix.stack.resolver }}
           cache-prefix: ${{ matrix.stack.resolver }}/
       
-      - if: matrix.stack.resolver != 'lts' && matrix.stack.resolver != 'nightly'
+      - if: matrix.stack.ghc
         shell: bash
         run: |
           [[ "${{ steps.stack.outputs.compiler }}" = ghc-${{ matrix.stack.ghc }} ]]

--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -51,8 +51,7 @@ jobs:
           stack-arguments: --resolver ${{ matrix.resolver }}
           cache-prefix: ${{ matrix.resolver }}/
 
-      - if:
-        shell: bash
+      - shell: bash
         run: |
           [[ "${{ steps.stack.outputs.compiler }}" = ${{ format('ghc-{0}', matrix.ghc) }} ]]
           [[ "${{ steps.stack.outputs.compiler-version }}" = ${{ matrix.ghc }} ]]

--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -22,14 +22,21 @@ jobs:
           - macOS-latest
           - windows-latest
 
-        resolver:
-          - nightly   # ghc-9.4 (as of writing)
-          - lts       # ghc-9.2 (as of writing)
-          - lts-20.2  # ghc-9.2
-          - lts-19.33 # ghc-9.0
-          - lts-18.28 # ghc-8.10
-          - lts-16.31 # ghc-8.8
-          - lts-12.26 # ghc-8.4
+        include:
+          - resolver: nightly
+            ghc: "9.8.1"
+          - resolver: lts-22.7
+            ghc: "9.6.4"
+          - resolver: lts-20.2
+            ghc: "9.2.5"
+          - resolver: lts-19.33
+            ghc: "9.0.2"
+          - resolver: lts-18.28
+            ghc: "8.10.7"
+          - resolver: lts-16.31
+            ghc: "8.8.4"
+          - resolver: lts-12.26
+            ghc: "8.4.4"
 
       fail-fast: false
 
@@ -44,10 +51,11 @@ jobs:
           stack-arguments: --resolver ${{ matrix.resolver }}
           cache-prefix: ${{ matrix.resolver }}/
 
-      - if: ${{ runner.os != 'windows' }}
+      - if:
+        shell: bash
         run: |
-          [[ "${{ steps.stack.outputs.compiler }}" = "ghc-8.10.4" ]]
-          [[ "${{ steps.stack.outputs.compiler-version }}" = "8.10.4" ]]
+          [[ "${{ steps.stack.outputs.compiler }}" = ${{ format('ghc-{0}', matrix.ghc) }} ]]
+          [[ "${{ steps.stack.outputs.compiler-version }}" = ${{ matrix.ghc }} ]]
 
           # stack path | cut -d: -f1
           [[ -n "${{ steps.stack.outputs.snapshot-doc-root }}" ]]

--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -22,7 +22,7 @@ jobs:
           - macOS-latest
           - windows-latest
 
-        include:
+        stack:
           - resolver: nightly
             ghc: "9.8.1"
           - resolver: lts-22.7
@@ -48,13 +48,13 @@ jobs:
         uses: ./
         with:
           working-directory: example
-          stack-arguments: --resolver ${{ matrix.resolver }}
-          cache-prefix: ${{ matrix.resolver }}/
+          stack-arguments: --resolver ${{ matrix.stack.resolver }}
+          cache-prefix: ${{ matrix.stack.resolver }}/
 
       - shell: bash
         run: |
-          [[ "${{ steps.stack.outputs.compiler }}" = ${{ format('ghc-{0}', matrix.ghc) }} ]]
-          [[ "${{ steps.stack.outputs.compiler-version }}" = ${{ matrix.ghc }} ]]
+          [[ "${{ steps.stack.outputs.compiler }}" = ${{ format('ghc-{0}', matrix.stack.ghc) }} ]]
+          [[ "${{ steps.stack.outputs.compiler-version }}" = ${{ matrix.stack.ghc }} ]]
 
           # stack path | cut -d: -f1
           [[ -n "${{ steps.stack.outputs.snapshot-doc-root }}" ]]

--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ inputs:
   stack-arguments:
     description: "Additional arguments for stack invocations"
     required: true
-    default: ""
+    default: "--no-terminal"
   stack-query-arguments:
     description: "Additional arguments in `stack query` invocations."
     required: true
@@ -152,7 +152,7 @@ runs:
 
         echo "resolver-nightly=$resolver_nightly" >>"$GITHUB_OUTPUT"
 
-        echo "stack-arguments=--no-terminal --stack-yaml ${{ inputs.stack-yaml }} $resolver_nightly $(echo "${{ inputs.stack-arguments }}" | tr '\n' ' ')" >>"$GITHUB_OUTPUT"
+        echo "stack-arguments=--stack-yaml ${{ inputs.stack-yaml }} $resolver_nightly $(echo "${{ inputs.stack-arguments }}" | tr '\n' ' ')" >>"$GITHUB_OUTPUT"
 
         echo 'stack-works<<EOM' >>"$GITHUB_OUTPUT"
         # We can't just list out '**/.stack-work' because the files may not

--- a/action.yml
+++ b/action.yml
@@ -9,14 +9,6 @@ inputs:
     description: "Override stack.yaml, relative to working-directory"
     required: true
     default: stack.yaml
-  fast:
-    description: "Pass --fast in build/test"
-    required: true
-    default: true
-  pedantic:
-    description: "Pass --pedantic in build/test"
-    required: true
-    default: true
   test:
     description: Whether to run tests
     required: false
@@ -40,7 +32,7 @@ inputs:
   stack-build-arguments:
     description: "Additional arguments in `stack build` invocations."
     required: true
-    default: ""
+    default: "--fast --pedantic"
   stack-build-arguments-dependencies:
     description: "Additional arguments passed after `stack-build-arguments` in `stack build` invocations on the `Dependencies` step."
     required: true
@@ -139,20 +131,9 @@ runs:
       run: |
         resolver_nightly=
 
-        # Extra arguments for build and test steps, not the dependencies step
-        stack_build_arguments=()
-
-        if ${{ inputs.fast }}; then
-          stack_build_arguments+=( --fast )
-        fi
-
-        if ${{ inputs.pedantic }}; then
-          stack_build_arguments+=( --pedantic )
-        fi
-
-        echo "stack-build-arguments-build=       ${stack_build_arguments[*]} ${{ inputs.stack-build-arguments }} ${{ inputs.stack-build-arguments-build        }}" >>"$GITHUB_OUTPUT"
-        echo "stack-build-arguments-dependencies=${stack_build_arguments[*]} ${{ inputs.stack-build-arguments }} ${{ inputs.stack-build-arguments-dependencies }}" >>"$GITHUB_OUTPUT"
-        echo "stack-build-arguments-test=        ${stack_build_arguments[*]} ${{ inputs.stack-build-arguments }} ${{ inputs.stack-build-arguments-test         }}" >>"$GITHUB_OUTPUT"
+        echo "stack-build-arguments-build=       ${{ inputs.stack-build-arguments }} ${{ inputs.stack-build-arguments-build        }}" >>"$GITHUB_OUTPUT"
+        echo "stack-build-arguments-dependencies=${{ inputs.stack-build-arguments }} ${{ inputs.stack-build-arguments-dependencies }}" >>"$GITHUB_OUTPUT"
+        echo "stack-build-arguments-test=        ${{ inputs.stack-build-arguments }} ${{ inputs.stack-build-arguments-test         }}" >>"$GITHUB_OUTPUT"
 
         has_resolver() {
           grep -Fq -- '--resolver' <<'EOM'

--- a/action.yml
+++ b/action.yml
@@ -38,19 +38,23 @@ inputs:
     required: true
     default: ""
   stack-build-arguments:
-    description: "Additional arguments in `stack build` invocations."
+    description: "Additional arguments in all `stack build` invocations. Can not be overriden by other action inputs."
+    required: true
+    default: ""
+  stack-build-arguments-default:
+    description: "Additional arguments in `stack build` invocations. Can be overriden by other action inputs."
     required: true
     default: ""
   stack-build-arguments-dependencies:
-    description: "When a non-empy string, overrides the input `stack-build-arguments` on the `Dependencies` step."
+    description: "When a non-empy string, overrides the input `stack-build-arguments-default` on the `Dependencies` step."
     required: true
     default: ""
   stack-build-arguments-build:
-    description: "When a non-empy string, overrides the input `stack-build-arguments` on the `Build` step."
+    description: "When a non-empy string, overrides the input `stack-build-arguments-default` on the `Build` step."
     required: true
     default: ""
   stack-build-arguments-test:
-    description: "When a non-empy string, overrides the input `stack-build-arguments` on the `Test` step."
+    description: "When a non-empy string, overrides the input `stack-build-arguments-default` on the `Test` step."
     required: true
     default: ""
   cache-prefix:
@@ -150,9 +154,9 @@ runs:
           stack_build_arguments+=( --pedantic )
         fi
 
-        echo "stack-build-arguments-build=       ${stack_build_arguments[*]} ${{ inputs.stack-build-arguments-build        != '' && inputs.stack-build-arguments-build        || inputs.stack-build-arguments }}" >>"$GITHUB_OUTPUT"
-        echo "stack-build-arguments-dependencies=${stack_build_arguments[*]} ${{ inputs.stack-build-arguments-dependencies != '' && inputs.stack-build-arguments-dependencies || inputs.stack-build-arguments }}" >>"$GITHUB_OUTPUT"
-        echo "stack-build-arguments-test=        ${stack_build_arguments[*]} ${{ inputs.stack-build-arguments-test         != '' && inputs.stack-build-arguments-test         || inputs.stack-build-arguments }}" >>"$GITHUB_OUTPUT"
+        echo "stack-build-arguments-build=       ${stack_build_arguments[*]} ${{ inputs.stack-build-arguments }} ${{ inputs.stack-build-arguments-build        != '' && inputs.stack-build-arguments-build        || inputs.stack-build-arguments-default }}" >>"$GITHUB_OUTPUT"
+        echo "stack-build-arguments-dependencies=${stack_build_arguments[*]} ${{ inputs.stack-build-arguments }} ${{ inputs.stack-build-arguments-dependencies != '' && inputs.stack-build-arguments-dependencies || inputs.stack-build-arguments-default }}" >>"$GITHUB_OUTPUT"
+        echo "stack-build-arguments-test=        ${stack_build_arguments[*]} ${{ inputs.stack-build-arguments }} ${{ inputs.stack-build-arguments-test         != '' && inputs.stack-build-arguments-test         || inputs.stack-build-arguments-default }}" >>"$GITHUB_OUTPUT"
 
         has_resolver() {
           grep -Fq -- '--resolver' <<'EOM'

--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,34 @@ inputs:
     description: "Additional arguments for stack invocations"
     required: true
     default: ""
+  stack-query-arguments:
+    description: "Additional arguments in `stack query` invocations."
+    required: true
+    default: ""
+  stack-path-arguments:
+    description: "Additional arguments in `stack path` invocations."
+    required: true
+    default: ""
+  stack-setup-arguments:
+    description: "Additional arguments in `stack setup` invocations."
+    required: true
+    default: ""
+  stack-build-arguments:
+    description: "Additional arguments in `stack build` invocations."
+    required: true
+    default: ""
+  stack-build-arguments-dependencies:
+    description: "When a non-empy string, overrides the input `stack-build-arguments` on the `Dependencies` step."
+    required: true
+    default: ""
+  stack-build-arguments-build:
+    description: "When a non-empy string, overrides the input `stack-build-arguments` on the `Build` step."
+    required: true
+    default: ""
+  stack-build-arguments-test:
+    description: "When a non-empy string, overrides the input `stack-build-arguments` on the `Test` step."
+    required: true
+    default: ""
   cache-prefix:
     required: true
     default: ""
@@ -122,6 +150,10 @@ runs:
           stack_build_arguments+=( --pedantic )
         fi
 
+        echo "stack-build-arguments-build=       ${stack_build_arguments[*]} ${{ inputs.stack-build-arguments-build        != '' && inputs.stack-build-arguments-build        || inputs.stack-build-arguments }}" >>"$GITHUB_OUTPUT"
+        echo "stack-build-arguments-dependencies=${stack_build_arguments[*]} ${{ inputs.stack-build-arguments-dependencies != '' && inputs.stack-build-arguments-dependencies || inputs.stack-build-arguments }}" >>"$GITHUB_OUTPUT"
+        echo "stack-build-arguments-test=        ${stack_build_arguments[*]} ${{ inputs.stack-build-arguments-test         != '' && inputs.stack-build-arguments-test         || inputs.stack-build-arguments }}" >>"$GITHUB_OUTPUT"
+
         has_resolver() {
           grep -Fq -- '--resolver' <<'EOM'
         ${{ inputs.stack-arguments }}
@@ -133,7 +165,8 @@ runs:
         fi
 
         echo "resolver-nightly=$resolver_nightly" >>"$GITHUB_OUTPUT"
-        echo "stack-build-arguments=${stack_build_arguments[*]}" >>"$GITHUB_OUTPUT"
+
+        echo "stack-arguments=--no-terminal --stack-yaml ${{ inputs.stack-yaml }} $resolver_nightly ${{ inputs.stack-arguments }}" >>"$GITHUB_OUTPUT"
 
         echo 'stack-works<<EOM' >>"$GITHUB_OUTPUT"
         # We can't just list out '**/.stack-work' because the files may not
@@ -174,9 +207,9 @@ runs:
         tmp=$(mktemp)
         trap 'rm -r "$tmp"' EXIT
 
-        stack --no-terminal --stack-yaml ${{ inputs.stack-yaml }} \
-          ${{ steps.setup.outputs.resolver-nightly }} \
-          query compiler | tee "$tmp"
+        stack ${{ steps.setup.outputs.stack-arguments }} \
+          query compiler ${{ inputs.stack-query-arguments }} \
+          | tee "$tmp"
 
         sed '/^actual: \(.*\)$/!d; s//compiler=\1/' "$tmp" >>"$GITHUB_OUTPUT"
         sed '/^actual: ghc-\(.*\)$/!d; s//compiler-version=\1/' "$tmp" >>"$GITHUB_OUTPUT"
@@ -186,9 +219,9 @@ runs:
       working-directory: ${{ inputs.working-directory }}
       shell: bash
       run: |
-        stack --no-terminal --stack-yaml ${{ inputs.stack-yaml }} \
-          ${{ steps.setup.outputs.resolver-nightly }} \
-          path | while IFS=:\  read -r name value; do
+        stack ${{ steps.setup.outputs.stack-arguments }} \
+          path ${{ inputs.stack-path-arguments }} \
+          | while IFS=:\  read -r name value; do
           printf '%s: %s\n' "$name" "$value"
           printf '%s=%s\n' "$name" "$value" >>"$GITHUB_OUTPUT"
         done
@@ -211,13 +244,11 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: |
-        stack --no-terminal --stack-yaml ${{ inputs.stack-yaml }} \
-          ${{ steps.setup.outputs.resolver-nightly }} \
-          setup
-        stack --no-terminal --stack-yaml ${{ inputs.stack-yaml }} \
-          ${{ steps.setup.outputs.resolver-nightly }} \
+        stack ${{ steps.setup.outputs.stack-arguments }} \
+          setup ${{ inputs.stack-setup-arguments }}
+        stack ${{ steps.setup.outputs.stack-arguments }} \
           build --dependencies-only --test --no-run-tests \
-          ${{ inputs.stack-arguments }}
+          ${{ steps.setup.outputs.stack-build-arguments-dependencies }}
 
     - name: Save dependencies cache
       if: steps.restore-deps.outputs.cache-hit != 'true'
@@ -244,11 +275,9 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: |
-        stack --no-terminal --stack-yaml ${{ inputs.stack-yaml }} \
-          ${{ steps.setup.outputs.resolver-nightly }} \
-          build ${{ steps.setup.outputs.stack-build-arguments }} \
-          --test --no-run-tests \
-          ${{ inputs.stack-arguments }}
+        stack ${{ steps.setup.outputs.stack-arguments }} \
+          build --test --no-run-tests \
+          ${{ steps.setup.outputs.stack-build-arguments-build }}
 
     - name: Save build cache
       if: steps.restore-build.outputs.cache-hit != 'true'
@@ -262,7 +291,6 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: |
-        stack --no-terminal --stack-yaml ${{ inputs.stack-yaml }} \
-          ${{ steps.setup.outputs.resolver-nightly }} \
-          build ${{ steps.setup.outputs.stack-build-arguments }} --test \
-          ${{ inputs.stack-arguments }}
+        stack ${{ steps.setup.outputs.stack-arguments }} \
+          build --test \
+          ${{ steps.setup.outputs.stack-build-arguments-test }}

--- a/action.yml
+++ b/action.yml
@@ -130,12 +130,12 @@ runs:
       working-directory: ${{ inputs.working-directory }}
       run: |
         {
-          echo "stack-query-arguments=              $(echo "${{ inputs.query-arguments       }}                                                 " | tr '\n' ' ')"
-          echo "stack-path-arguments=               $(echo "${{ inputs.path-arguments        }}                                                 " | tr '\n' ' ')"
-          echo "stack-setup-arguments=              $(echo "${{ inputs.setup-arguments       }}                                                 " | tr '\n' ' ')"
-          echo "stack-build-arguments-dependencies= $(echo "${{ inputs.stack-build-arguments }} ${{ inputs.stack-build-arguments-dependencies }}" | tr '\n' ' ')"
-          echo "stack-build-arguments-build=        $(echo "${{ inputs.stack-build-arguments }} ${{ inputs.stack-build-arguments-build        }}" | tr '\n' ' ')"
-          echo "stack-build-arguments-test=         $(echo "${{ inputs.stack-build-arguments }} ${{ inputs.stack-build-arguments-test         }}" | tr '\n' ' ')"
+          echo "stack-query-arguments=$(             echo "${{ inputs.query-arguments                                                        }}" | tr '\n' ' ')"
+          echo "stack-path-arguments=$(              echo "${{ inputs.path-arguments                                                         }}" | tr '\n' ' ')"
+          echo "stack-setup-arguments=$(             echo "${{ inputs.setup-arguments                                                        }}" | tr '\n' ' ')"
+          echo "stack-build-arguments-dependencies=$(echo "${{ inputs.stack-build-arguments }} ${{ inputs.stack-build-arguments-dependencies }}" | tr '\n' ' ')"
+          echo "stack-build-arguments-build=$(       echo "${{ inputs.stack-build-arguments }} ${{ inputs.stack-build-arguments-build        }}" | tr '\n' ' ')"
+          echo "stack-build-arguments-test=$(        echo "${{ inputs.stack-build-arguments }} ${{ inputs.stack-build-arguments-test         }}" | tr '\n' ' ')"
         } >> "$GITHUB_OUTPUT"
 
         has_resolver() {

--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ inputs:
     required: false
     default: true
   stack-arguments:
-    description: "Additional arguments for stack invocations"
+    description: "Additional arguments for all top-level `stack` command invocations."
     required: true
     default: "--no-terminal"
   stack-query-arguments:

--- a/action.yml
+++ b/action.yml
@@ -38,23 +38,19 @@ inputs:
     required: true
     default: ""
   stack-build-arguments:
-    description: "Additional arguments in all `stack build` invocations. Can not be overriden by other action inputs."
-    required: true
-    default: ""
-  stack-build-arguments-default:
-    description: "Additional arguments in `stack build` invocations. Can be overriden by other action inputs."
+    description: "Additional arguments in `stack build` invocations."
     required: true
     default: ""
   stack-build-arguments-dependencies:
-    description: "When a non-empy string, overrides the input `stack-build-arguments-default` on the `Dependencies` step."
+    description: "Additional arguments passed after `stack-build-arguments` in `stack build` invocations on the `Dependencies` step."
     required: true
     default: ""
   stack-build-arguments-build:
-    description: "When a non-empy string, overrides the input `stack-build-arguments-default` on the `Build` step."
+    description: "Additional arguments passed after `stack-build-arguments` in `stack build` invocations on the `Build` step."
     required: true
     default: ""
   stack-build-arguments-test:
-    description: "When a non-empy string, overrides the input `stack-build-arguments-default` on the `Test` step."
+    description: "Additional arguments passed after `stack-build-arguments` in `stack build` invocations on the `Test` step."
     required: true
     default: ""
   cache-prefix:
@@ -154,9 +150,9 @@ runs:
           stack_build_arguments+=( --pedantic )
         fi
 
-        echo "stack-build-arguments-build=       ${stack_build_arguments[*]} ${{ inputs.stack-build-arguments }} ${{ inputs.stack-build-arguments-build        != '' && inputs.stack-build-arguments-build        || inputs.stack-build-arguments-default }}" >>"$GITHUB_OUTPUT"
-        echo "stack-build-arguments-dependencies=${stack_build_arguments[*]} ${{ inputs.stack-build-arguments }} ${{ inputs.stack-build-arguments-dependencies != '' && inputs.stack-build-arguments-dependencies || inputs.stack-build-arguments-default }}" >>"$GITHUB_OUTPUT"
-        echo "stack-build-arguments-test=        ${stack_build_arguments[*]} ${{ inputs.stack-build-arguments }} ${{ inputs.stack-build-arguments-test         != '' && inputs.stack-build-arguments-test         || inputs.stack-build-arguments-default }}" >>"$GITHUB_OUTPUT"
+        echo "stack-build-arguments-build=       ${stack_build_arguments[*]} ${{ inputs.stack-build-arguments }} ${{ inputs.stack-build-arguments-build        }}" >>"$GITHUB_OUTPUT"
+        echo "stack-build-arguments-dependencies=${stack_build_arguments[*]} ${{ inputs.stack-build-arguments }} ${{ inputs.stack-build-arguments-dependencies }}" >>"$GITHUB_OUTPUT"
+        echo "stack-build-arguments-test=        ${stack_build_arguments[*]} ${{ inputs.stack-build-arguments }} ${{ inputs.stack-build-arguments-test         }}" >>"$GITHUB_OUTPUT"
 
         has_resolver() {
           grep -Fq -- '--resolver' <<'EOM'

--- a/action.yml
+++ b/action.yml
@@ -129,9 +129,14 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: |
-        echo "stack-build-arguments-build=       ${{ inputs.stack-build-arguments }} ${{ inputs.stack-build-arguments-build        }}" >>"$GITHUB_OUTPUT"
-        echo "stack-build-arguments-dependencies=${{ inputs.stack-build-arguments }} ${{ inputs.stack-build-arguments-dependencies }}" >>"$GITHUB_OUTPUT"
-        echo "stack-build-arguments-test=        ${{ inputs.stack-build-arguments }} ${{ inputs.stack-build-arguments-test         }}" >>"$GITHUB_OUTPUT"
+        {
+          echo "stack-query-arguments=              $(echo "${{ inputs.query-arguments       }}                                                 " | tr '\n' ' ')"
+          echo "stack-path-arguments=               $(echo "${{ inputs.path-arguments        }}                                                 " | tr '\n' ' ')"
+          echo "stack-setup-arguments=              $(echo "${{ inputs.setup-arguments       }}                                                 " | tr '\n' ' ')"
+          echo "stack-build-arguments-dependencies= $(echo "${{ inputs.stack-build-arguments }} ${{ inputs.stack-build-arguments-dependencies }}" | tr '\n' ' ')"
+          echo "stack-build-arguments-build=        $(echo "${{ inputs.stack-build-arguments }} ${{ inputs.stack-build-arguments-build        }}" | tr '\n' ' ')"
+          echo "stack-build-arguments-test=         $(echo "${{ inputs.stack-build-arguments }} ${{ inputs.stack-build-arguments-test         }}" | tr '\n' ' ')"
+        } >> "$GITHUB_OUTPUT"
 
         has_resolver() {
           grep -Fq -- '--resolver' <<'EOM'
@@ -147,7 +152,7 @@ runs:
 
         echo "resolver-nightly=$resolver_nightly" >>"$GITHUB_OUTPUT"
 
-        echo "stack-arguments=--no-terminal --stack-yaml ${{ inputs.stack-yaml }} $resolver_nightly ${{ inputs.stack-arguments }}" >>"$GITHUB_OUTPUT"
+        echo "stack-arguments=--no-terminal --stack-yaml ${{ inputs.stack-yaml }} $resolver_nightly $(echo "${{ inputs.stack-arguments }}" | tr '\n' ' ')" >>"$GITHUB_OUTPUT"
 
         echo 'stack-works<<EOM' >>"$GITHUB_OUTPUT"
         # We can't just list out '**/.stack-work' because the files may not
@@ -189,7 +194,7 @@ runs:
         trap 'rm -r "$tmp"' EXIT
 
         stack ${{ steps.setup.outputs.stack-arguments }} \
-          query compiler ${{ inputs.stack-query-arguments }} \
+          query compiler ${{ steps.setup.outputs.stack-query-arguments }} \
           | tee "$tmp"
 
         sed '/^actual: \(.*\)$/!d; s//compiler=\1/' "$tmp" >>"$GITHUB_OUTPUT"
@@ -201,7 +206,7 @@ runs:
       shell: bash
       run: |
         stack ${{ steps.setup.outputs.stack-arguments }} \
-          path ${{ inputs.stack-path-arguments }} \
+          path ${{ steps.setup.outputs.stack-path-arguments }} \
           | while IFS=:\  read -r name value; do
           printf '%s: %s\n' "$name" "$value"
           printf '%s=%s\n' "$name" "$value" >>"$GITHUB_OUTPUT"
@@ -226,7 +231,7 @@ runs:
       working-directory: ${{ inputs.working-directory }}
       run: |
         stack ${{ steps.setup.outputs.stack-arguments }} \
-          setup ${{ inputs.stack-setup-arguments }}
+          setup ${{ steps.setup.outputs.stack-setup-arguments }}
         stack ${{ steps.setup.outputs.stack-arguments }} \
           build --dependencies-only --test --no-run-tests \
           ${{ steps.setup.outputs.stack-build-arguments-dependencies }}

--- a/action.yml
+++ b/action.yml
@@ -30,7 +30,7 @@ inputs:
     required: true
     default: ""
   stack-build-arguments:
-    description: "Additional arguments in `stack build` invocations."
+    description: "Additional arguments for all `stack build` invocations."
     required: true
     default: "--fast --pedantic"
   stack-build-arguments-dependencies:

--- a/action.yml
+++ b/action.yml
@@ -129,8 +129,6 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: |
-        resolver_nightly=
-
         echo "stack-build-arguments-build=       ${{ inputs.stack-build-arguments }} ${{ inputs.stack-build-arguments-build        }}" >>"$GITHUB_OUTPUT"
         echo "stack-build-arguments-dependencies=${{ inputs.stack-build-arguments }} ${{ inputs.stack-build-arguments-dependencies }}" >>"$GITHUB_OUTPUT"
         echo "stack-build-arguments-test=        ${{ inputs.stack-build-arguments }} ${{ inputs.stack-build-arguments-test         }}" >>"$GITHUB_OUTPUT"
@@ -140,6 +138,8 @@ runs:
         ${{ inputs.stack-arguments }}
         EOM
         }
+
+        resolver_nightly=
 
         if ! has_resolver && [[ "${{ inputs.stack-yaml }}" == 'stack-nightly.yaml' ]]; then
           resolver_nightly='--resolver nightly'


### PR DESCRIPTION
- Add new inputs to provide separate arguments for `stack <command>` invocations
- `stack-arguments` are now passed to `stack` invocations (closes #26)
- Fix compiler checks in the example action
- Run example action on all platforms
- Convert multi-line inputs to single-line strings