### PR TITLE
Fix action-docs version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "devDependencies": {
-        "action-docs": "git+https://github.com/deemp/action-docs.git#0cb0ac2c40736aba24c4fd5097f1074b5a7c7a4b",
+        "action-docs": "github:npalm/action-docs",
         "prettier": "^3.2.4",
         "typescript": "^5.3.0"
       }
@@ -190,8 +190,7 @@
     },
     "node_modules/action-docs": {
       "version": "2.0.0",
-      "resolved": "git+ssh://git@github.com/deemp/action-docs.git#0cb0ac2c40736aba24c4fd5097f1074b5a7c7a4b",
-      "integrity": "sha512-MoNVvZbjkxovq3+zbL/QmEfCIufj9Tf6cvgD7dCJ5f432QHlriy6xGk2CoslJ/W1CRtGQRlsGSXO5g07MJvnLA==",
+      "resolved": "git+ssh://git@github.com/npalm/action-docs.git#e1f40b0aced3cc3a520bfd64b94b2fb5f776b9f4",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "devDependencies": {
-    "typescript": "^5.3.0",
+    "action-docs": "github:npalm/action-docs",
     "prettier": "^3.2.4",
-    "action-docs": "git+https://github.com/deemp/action-docs.git#0cb0ac2c40736aba24c4fd5097f1074b5a7c7a4b"
+    "typescript": "^5.3.0"
   },
   "scripts": {
     "readme": "npx action-docs -u && prettier --write README.md"


### PR DESCRIPTION
The https://github.com/npalm/action-docs/pull/505 is now merged. Hence, we can now use the original repo.