### PR TITLE
fix: use a released version of action-docs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "devDependencies": {
-        "action-docs": "github:npalm/action-docs",
+        "action-docs": "^2.0.0",
         "prettier": "^3.2.4",
         "typescript": "^5.3.0"
       }
@@ -190,9 +190,9 @@
     },
     "node_modules/action-docs": {
       "version": "2.0.0",
-      "resolved": "git+ssh://git@github.com/npalm/action-docs.git#e1f40b0aced3cc3a520bfd64b94b2fb5f776b9f4",
+      "resolved": "https://registry.npmjs.org/action-docs/-/action-docs-2.0.0.tgz",
+      "integrity": "sha512-AT46HljUncSwJQAF2cojGzpFKzth9eV11as1zSJ5KPp3un0yreFNEwYvr4Zwip37fR64szeGgLyNn8dOFgW1yg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",
         "eslint-import-resolver-typescript": "^3.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
-    "action-docs": "github:npalm/action-docs",
+    "action-docs": "^2.0.0",
     "prettier": "^3.2.4",
     "typescript": "^5.3.0"
   },


### PR DESCRIPTION
I've just noticed the author has released the package on npmjs.