### PR TITLE
Deprecate stack-yaml input

### DIFF
--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -104,4 +104,4 @@ jobs:
       - uses: ./
         with:
           working-directory: example
-          stack-yaml: ${{ matrix.stack-yaml }}
+          stack-arguments: --stack-yaml ${{ matrix.stack-yaml }}

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ jobs:
 | `stack-build-arguments-test`         | <p>Additional arguments passed after <code>stack-build-arguments</code> in <code>stack build</code> invocations on the <em>Test</em> step.</p>                                                            | `false`  | `""`                |
 | `cache-prefix`                       | <p>Prefix applied to all cache keys. This can be any value you like, but teams often use <code>v{N}</code> and bump it to <code>v{N+1}</code> when/if they need to explicitly bust caches.</p>            | `false`  | `""`                |
 | `cache-save-always`                  | <p>Save artifacts to the cache even if the build fails. This may speed up builds in subsequent runs at the expense of slightly-longer builds when a full cache-hit occurs. Since <code>@v4.2.0</code></p> | `false`  | `false`             |
+| `upgrade-stack`                      | <p>Upgrade stack</p>                                                                                                                                                                                      | `false`  | `true`              |
 
 <!-- action-docs-inputs action="action.yml" -->
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,6 @@ jobs:
 | name                                 | description                                                                                                                                                                                               | required | default             |
 | ------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------------------- |
 | `working-directory`                  | <p>Working directory for run commands</p>                                                                                                                                                                 | `false`  | `""`                |
-| `stack-yaml`                         | <p>Override stack.yaml, relative to working-directory</p>                                                                                                                                                 | `false`  | `stack.yaml`        |
 | `test`                               | <p>Whether to run tests</p>                                                                                                                                                                               | `false`  | `true`              |
 | `stack-arguments`                    | <p>Additional arguments for all top-level <code>stack</code> command invocations.</p>                                                                                                                     | `false`  | `--no-terminal`     |
 | `stack-query-arguments`              | <p>Additional arguments in <code>stack query</code> invocations.</p>                                                                                                                                      | `false`  | `""`                |
@@ -82,6 +81,7 @@ jobs:
 | `cache-prefix`                       | <p>Prefix applied to all cache keys. This can be any value you like, but teams often use <code>v{N}</code> and bump it to <code>v{N+1}</code> when/if they need to explicitly bust caches.</p>            | `false`  | `""`                |
 | `cache-save-always`                  | <p>Save artifacts to the cache even if the build fails. This may speed up builds in subsequent runs at the expense of slightly-longer builds when a full cache-hit occurs. Since <code>@v4.2.0</code></p> | `false`  | `false`             |
 | `upgrade-stack`                      | <p>Upgrade stack</p>                                                                                                                                                                                      | `false`  | `true`              |
+| `stack-yaml`                         | <p><strong>Deprecated</strong> use <code>env.STACK_YAML</code> or <code>stack-arguments</code> instead.</p>                                                                                               | `false`  | `""`                |
 
 <!-- action-docs-inputs action="action.yml" -->
 
@@ -142,7 +142,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: freckle/stack-action@v5
         with:
-          stack-yaml: ${{ matrix.stack-yaml }}
+          stack-arguments: --stack-yaml ${{ matrix.stack-yaml }}
 ```
 
 See [generate-matrix/action.yml](./generate-matrix/action.yml) for more details.

--- a/action.yml
+++ b/action.yml
@@ -4,10 +4,6 @@ inputs:
   working-directory:
     description: |
       Working directory for run commands
-  stack-yaml:
-    description: |
-      Override stack.yaml, relative to working-directory
-    default: "stack.yaml"
   test:
     description: |
       Whether to run tests
@@ -56,6 +52,9 @@ inputs:
     description: |
       Upgrade stack
     default: true
+  stack-yaml:
+    description: |
+      **Deprecated** use `env.STACK_YAML` or `stack-arguments` instead.
 runs:
   using: "node20"
   main: "dist/index.js"

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,4 +3,9 @@ module.exports = {
   preset: "ts-jest",
   testEnvironment: "node",
   resetMocks: true,
+  globals: {
+    "ts-jest": {
+      isolatedModules: true,
+    },
+  },
 };

--- a/src/inputs.ts
+++ b/src/inputs.ts
@@ -4,7 +4,6 @@ import { envsubst } from "./envsubst";
 
 export type Inputs = {
   workingDirectory: string | null;
-  stackYaml: string;
   test: boolean;
   stackArguments: string[];
   stackSetupArguments: string[];
@@ -15,6 +14,9 @@ export type Inputs = {
   cachePrefix: string;
   cacheSaveAlways: boolean;
   upgradeStack: boolean;
+
+  // Deprecated
+  stackYaml: string | null;
 };
 
 export function getInputs(): Inputs {
@@ -26,7 +28,6 @@ export function getInputs(): Inputs {
 
   return {
     workingDirectory: getInputDefault("working-directory", null),
-    stackYaml: getInputDefault("stack-yaml", "stack.yaml"),
     test: core.getBooleanInput("test"),
     stackArguments: getShellWordsInput("stack-arguments"),
     stackSetupArguments: getShellWordsInput("stack-setup-arguments"),
@@ -37,6 +38,7 @@ export function getInputs(): Inputs {
     cachePrefix: core.getInput("cache-prefix"),
     cacheSaveAlways: core.getBooleanInput("cache-save-always"),
     upgradeStack: core.getBooleanInput("upgrade-stack"),
+    stackYaml: getInputDefault("stack-yaml", null),
   };
 }
 

--- a/src/stack-cli.test.ts
+++ b/src/stack-cli.test.ts
@@ -5,36 +5,23 @@ import { StackCLI } from "./stack-cli";
 jest.spyOn(exec, "exec");
 
 describe("StackCLI", () => {
-  test("Adds --stack-yaml", async () => {
-    const stackCLI = new StackCLI("my-stack.yaml", [], false);
-
-    await stackCLI.setup([]);
-
-    expect(exec.exec).toHaveBeenCalledWith(
-      "stack",
-      ["--stack-yaml", "my-stack.yaml", "setup"],
-      undefined, // ExecOptions
-    );
-  });
-
   test("Respects --resolver given", async () => {
-    const stackCLI = new StackCLI(
-      "my-stack.yaml",
-      ["--resolver", "lts"],
-      false,
-    );
+    const stackCLI = new StackCLI(["--resolver", "lts"], false);
 
     await stackCLI.setup([]);
 
     expect(exec.exec).toHaveBeenCalledWith(
       "stack",
-      ["--stack-yaml", "my-stack.yaml", "--resolver", "lts", "setup"],
+      ["--resolver", "lts", "setup"],
       undefined, // ExecOptions
     );
   });
 
   test("Adds --resolver nightly", async () => {
-    const stackCLI = new StackCLI("sub/stack-nightly.yaml", [], false);
+    const stackCLI = new StackCLI(
+      ["--stack-yaml", "sub/stack-nightly.yaml"],
+      false,
+    );
 
     await stackCLI.setup([]);
 
@@ -53,8 +40,12 @@ describe("StackCLI", () => {
 
   test("Doesn't add --resolver nightly if given", async () => {
     const stackCLI = new StackCLI(
-      "sub/stack-nightly.yaml",
-      ["--resolver", "nightly-20240201"],
+      [
+        "--stack-yaml",
+        "sub/stack-nightly.yaml",
+        "--resolver",
+        "nightly-20240201",
+      ],
       false,
     );
 
@@ -74,15 +65,13 @@ describe("StackCLI", () => {
   });
 
   test("buildDependencies", async () => {
-    const stackCLI = new StackCLI("stack.yaml", [], false);
+    const stackCLI = new StackCLI([], false);
 
     await stackCLI.buildDependencies(["--coverage"]);
 
     expect(exec.exec).toHaveBeenCalledWith(
       "stack",
       [
-        "--stack-yaml",
-        "stack.yaml",
         "build",
         "--test",
         "--no-run-tests",
@@ -94,44 +83,37 @@ describe("StackCLI", () => {
   });
 
   test("buildNoTest", async () => {
-    const stackCLI = new StackCLI("stack.yaml", [], false);
+    const stackCLI = new StackCLI([], false);
 
     await stackCLI.buildNoTest(["--coverage"]);
 
     expect(exec.exec).toHaveBeenCalledWith(
       "stack",
-      [
-        "--stack-yaml",
-        "stack.yaml",
-        "build",
-        "--test",
-        "--no-run-tests",
-        "--coverage",
-      ],
+      ["build", "--test", "--no-run-tests", "--coverage"],
       undefined,
     );
   });
 
   test("buildTest", async () => {
-    const stackCLI = new StackCLI("stack.yaml", [], false);
+    const stackCLI = new StackCLI([], false);
 
     await stackCLI.buildTest(["--coverage"]);
 
     expect(exec.exec).toHaveBeenCalledWith(
       "stack",
-      ["--stack-yaml", "stack.yaml", "build", "--test", "--coverage"],
+      ["build", "--test", "--coverage"],
       undefined,
     );
   });
 
   test("build", async () => {
-    const stackCLI = new StackCLI("stack.yaml", [], false);
+    const stackCLI = new StackCLI([], false);
 
     await stackCLI.build(["--coverage"]);
 
     expect(exec.exec).toHaveBeenCalledWith(
       "stack",
-      ["--stack-yaml", "stack.yaml", "build", "--coverage"],
+      ["build", "--coverage"],
       undefined,
     );
   });

--- a/src/stack-yaml.test.ts
+++ b/src/stack-yaml.test.ts
@@ -2,7 +2,7 @@ import { parseStackYaml, getStackDirectories } from "./stack-yaml";
 import { StackCLI } from "./stack-cli";
 
 function mockStackCLI(stackRoot: string = "/home/me/.stack"): StackCLI {
-  const stack = new StackCLI("stack.yaml", []);
+  const stack = new StackCLI([]);
 
   jest
     .spyOn(stack, "read")


### PR DESCRIPTION
### [Set isolatedModules: true](https://github.com/freckle/stack-action/pull/50/commits/1a48f8569ae425680caa6846cc51f320057b11f3)
[1a48f85](https://github.com/freckle/stack-action/pull/50/commits/1a48f8569ae425680caa6846cc51f320057b11f3)

See https://stackoverflow.com/a/60905543

This brought the test suite down from ~6s to ~1s on my machine.

### [Commit forgotten README update](https://github.com/freckle/stack-action/pull/50/commits/add9aad2b63e041294fea70fad7038b40bdb2ab9)
[add9aad](https://github.com/freckle/stack-action/pull/50/commits/add9aad2b63e041294fea70fad7038b40bdb2ab9)

### [Remove stack-yaml input](https://github.com/freckle/stack-action/pull/50/commits/7d8662b4d6fe3407d6c68bcd3a76b2a81ffae739)
[7d8662b](https://github.com/freckle/stack-action/pull/50/commits/7d8662b4d6fe3407d6c68bcd3a76b2a81ffae739)

Users can either set `STACK_YAML` or `stack-arguments` to add
`--stack-yaml`, which each come with their own trade-offs depending on
the nature of the Job in which this action is used. Either way, a
dedicated input is not necessary or useful.

Before this commit, users who set `STACK_YAML` _and_ used
`inputs.stack-yaml` could get themselves in trouble if they weren't
careful.

I decided to keep the input for now, to avoid needing a major version
bump but:

- Documentation says it's deprecated
- It triggers a warning
- It results in naively pushing the value into `stack-arguments`, which
  is what the behavior was before, but might misbehave if the user is
  also setting `env.STACK_YAML` or already has `--stack-yaml` in
  `stack-arguments`, which was also the behavior before, I guess