### PR TITLE
Support installing compiler-tools with dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,22 +66,23 @@ jobs:
 
 ## Inputs
 
-| name                                 | description                                                                                                                                                                                               | required | default             |
-| ------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------------------- |
-| `working-directory`                  | <p>Working directory for run commands</p>                                                                                                                                                                 | `false`  | `""`                |
-| `test`                               | <p>Whether to run tests</p>                                                                                                                                                                               | `false`  | `true`              |
-| `stack-arguments`                    | <p>Additional arguments for all top-level <code>stack</code> command invocations.</p>                                                                                                                     | `false`  | `--no-terminal`     |
-| `stack-query-arguments`              | <p>Additional arguments in <code>stack query</code> invocations.</p>                                                                                                                                      | `false`  | `""`                |
-| `stack-path-arguments`               | <p>Additional arguments in <code>stack path</code> invocations.</p>                                                                                                                                       | `false`  | `""`                |
-| `stack-setup-arguments`              | <p>Additional arguments in <code>stack setup</code> invocations.</p>                                                                                                                                      | `false`  | `""`                |
-| `stack-build-arguments`              | <p>Additional arguments for all <code>stack build</code> invocations.</p>                                                                                                                                 | `false`  | `--fast --pedantic` |
-| `stack-build-arguments-dependencies` | <p>Additional arguments passed after <code>stack-build-arguments</code> in <code>stack build</code> invocations on the <em>Dependencies</em> step.</p>                                                    | `false`  | `""`                |
-| `stack-build-arguments-build`        | <p>Additional arguments passed after <code>stack-build-arguments</code> in <code>stack build</code> invocations on the <em>Build</em> step.</p>                                                           | `false`  | `""`                |
-| `stack-build-arguments-test`         | <p>Additional arguments passed after <code>stack-build-arguments</code> in <code>stack build</code> invocations on the <em>Test</em> step.</p>                                                            | `false`  | `""`                |
-| `cache-prefix`                       | <p>Prefix applied to all cache keys. This can be any value you like, but teams often use <code>v{N}</code> and bump it to <code>v{N+1}</code> when/if they need to explicitly bust caches.</p>            | `false`  | `""`                |
-| `cache-save-always`                  | <p>Save artifacts to the cache even if the build fails. This may speed up builds in subsequent runs at the expense of slightly-longer builds when a full cache-hit occurs. Since <code>@v4.2.0</code></p> | `false`  | `false`             |
-| `upgrade-stack`                      | <p>Upgrade stack</p>                                                                                                                                                                                      | `false`  | `true`              |
-| `stack-yaml`                         | <p><strong>Deprecated</strong> use <code>env.STACK_YAML</code> or <code>stack-arguments</code> instead.</p>                                                                                               | `false`  | `""`                |
+| name                                 | description                                                                                                                                                                                                                                    | required | default             |
+| ------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------------------- |
+| `working-directory`                  | <p>Working directory for run commands</p>                                                                                                                                                                                                      | `false`  | `""`                |
+| `test`                               | <p>Whether to run tests</p>                                                                                                                                                                                                                    | `false`  | `true`              |
+| `stack-arguments`                    | <p>Additional arguments for all top-level <code>stack</code> command invocations.</p>                                                                                                                                                          | `false`  | `--no-terminal`     |
+| `stack-query-arguments`              | <p>Additional arguments in <code>stack query</code> invocations.</p>                                                                                                                                                                           | `false`  | `""`                |
+| `stack-path-arguments`               | <p>Additional arguments in <code>stack path</code> invocations.</p>                                                                                                                                                                            | `false`  | `""`                |
+| `stack-setup-arguments`              | <p>Additional arguments in <code>stack setup</code> invocations.</p>                                                                                                                                                                           | `false`  | `""`                |
+| `stack-build-arguments`              | <p>Additional arguments for all <code>stack build</code> invocations.</p>                                                                                                                                                                      | `false`  | `--fast --pedantic` |
+| `stack-build-arguments-dependencies` | <p>Additional arguments passed after <code>stack-build-arguments</code> in <code>stack build</code> invocations on the <em>Dependencies</em> step.</p>                                                                                         | `false`  | `""`                |
+| `stack-build-arguments-build`        | <p>Additional arguments passed after <code>stack-build-arguments</code> in <code>stack build</code> invocations on the <em>Build</em> step.</p>                                                                                                | `false`  | `""`                |
+| `stack-build-arguments-test`         | <p>Additional arguments passed after <code>stack-build-arguments</code> in <code>stack build</code> invocations on the <em>Test</em> step.</p>                                                                                                 | `false`  | `""`                |
+| `cache-prefix`                       | <p>Prefix applied to all cache keys. This can be any value you like, but teams often use <code>v{N}</code> and bump it to <code>v{N+1}</code> when/if they need to explicitly bust caches.</p>                                                 | `false`  | `""`                |
+| `cache-save-always`                  | <p>Save artifacts to the cache even if the build fails. This may speed up builds in subsequent runs at the expense of slightly-longer builds when a full cache-hit occurs. Since <code>@v4.2.0</code>.</p>                                     | `false`  | `false`             |
+| `upgrade-stack`                      | <p>Upgrade stack</p>                                                                                                                                                                                                                           | `false`  | `true`              |
+| `compiler-tools`                     | <p>A list of packages to install as compiler tools, one per line. This is useful to do here rather than separate <code>run</code> commands so that their installation is incorporated in the dependency cache. Since <code>@v5.2.0</code>.</p> | `false`  | `""`                |
+| `stack-yaml`                         | <p><strong>Deprecated</strong> use <code>env.STACK_YAML</code> or <code>stack-arguments</code> instead.</p>                                                                                                                                    | `false`  | `""`                |
 
 <!-- action-docs-inputs action="action.yml" -->
 
@@ -113,6 +114,32 @@ jobs:
 | `local-install-root`    | <p><code>local-install-root</code> value from <code>stack path</code></p>    |
 | `dist-dir`              | <p><code>dist-dir</code> value from <code>stack path</code></p>              |
 | `local-hpc-root`        | <p><code>local-hpc-root</code> value from <code>stack path</code></p>        |
+
+## Installing Compiler Tools
+
+The `compiler-tools` input can be used to install packages (with
+`--copy-compiler-tool`) as part of the _Dependencies_ step. The installed tools
+can be used by other parts of the build via `stack exec`, such as to reformat
+and upload coverage:
+
+```yaml
+- id: stack
+  uses: freckle/stack-action@v5
+  with:
+    compiler-tools: hpc-lcov
+    stack-build-arguments: --coverage
+
+- run: stack --no-terminal exec -- hpc-lcov --file "$HPC_ROOT"/combined/all/all.tix
+  env:
+    HPC_ROOT: ${{ steps.stack.outputs.local-hpc-root }}
+
+- uses: codecov/codecov-action@v2
+  with:
+    files: ./lcov.info
+```
+
+Doing it this way, vs a separate `run: stack install...`, means the building of
+these tools will be included in the dependencies cache.
 
 ## Generating a Build Matrix of `stack.yaml`s
 

--- a/action.yml
+++ b/action.yml
@@ -46,12 +46,17 @@ inputs:
     description: |
       Save artifacts to the cache even if the build fails. This may speed up
       builds in subsequent runs at the expense of slightly-longer builds when a
-      full cache-hit occurs. Since `@v4.2.0`
+      full cache-hit occurs. Since `@v4.2.0`.
     default: false
   upgrade-stack:
     description: |
       Upgrade stack
     default: true
+  compiler-tools:
+    description: |
+      A list of packages to install as compiler tools, one per line. This is
+      useful to do here rather than separate `run` commands so that their
+      installation is incorporated in the dependency cache. Since `@v5.2.0`.
   stack-yaml:
     description: |
       **Deprecated** use `env.STACK_YAML` or `stack-arguments` instead.

--- a/dist/index.js
+++ b/dist/index.js
@@ -137,6 +137,7 @@ function getInputs() {
         cachePrefix: core.getInput("cache-prefix"),
         cacheSaveAlways: core.getBooleanInput("cache-save-always"),
         upgradeStack: core.getBooleanInput("upgrade-stack"),
+        compilerTools: core.getMultilineInput("compiler-tools"),
         stackYaml: getInputDefault("stack-yaml", null),
     };
 }
@@ -230,6 +231,7 @@ async function run() {
             await (0, with_cache_1.withCache)([stackRoot, stackPrograms].concat(stackWorks), (0, get_cache_keys_1.getCacheKeys)([`${cachePrefix}/deps`, hashes.snapshot, hashes.package]), async () => {
                 await stack.setup(inputs.stackSetupArguments);
                 await stack.buildDependencies(inputs.stackBuildArgumentsDependencies);
+                await stack.installCompilerTools(inputs.compilerTools);
             }, {
                 ...with_cache_1.DEFAULT_CACHE_OPTIONS,
                 saveOnError: inputs.cacheSaveAlways,
@@ -431,6 +433,12 @@ class StackCLI {
     }
     async setup(args) {
         return await this.exec(["setup"].concat(args));
+    }
+    async installCompilerTools(tools) {
+        if (tools.length > 0) {
+            return await this.exec(["install", "--copy-compiler-tool"].concat(tools));
+        }
+        return 0;
     }
     async buildDependencies(args) {
         return await this.buildNoTest(["--dependencies-only"].concat(args));

--- a/src/inputs.ts
+++ b/src/inputs.ts
@@ -14,6 +14,7 @@ export type Inputs = {
   cachePrefix: string;
   cacheSaveAlways: boolean;
   upgradeStack: boolean;
+  compilerTools: string[];
 
   // Deprecated
   stackYaml: string | null;
@@ -38,6 +39,7 @@ export function getInputs(): Inputs {
     cachePrefix: core.getInput("cache-prefix"),
     cacheSaveAlways: core.getBooleanInput("cache-save-always"),
     upgradeStack: core.getBooleanInput("upgrade-stack"),
+    compilerTools: core.getMultilineInput("compiler-tools"),
     stackYaml: getInputDefault("stack-yaml", null),
   };
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -78,6 +78,7 @@ async function run() {
         async () => {
           await stack.setup(inputs.stackSetupArguments);
           await stack.buildDependencies(inputs.stackBuildArgumentsDependencies);
+          await stack.installCompilerTools(inputs.compilerTools);
         },
         {
           ...DEFAULT_CACHE_OPTIONS,

--- a/src/stack-cli.test.ts
+++ b/src/stack-cli.test.ts
@@ -64,6 +64,24 @@ describe("StackCLI", () => {
     );
   });
 
+  test("installCompilerTools", async () => {
+    const stackCLI = new StackCLI([], false);
+    await stackCLI.installCompilerTools(["hlint", "weeder"]);
+
+    expect(exec.exec).toHaveBeenCalledWith(
+      "stack",
+      ["install", "--copy-compiler-tool", "hlint", "weeder"],
+      undefined,
+    );
+  });
+
+  test("installCompilerTools with empty arguments", async () => {
+    const stackCLI = new StackCLI([], false);
+    await stackCLI.installCompilerTools([]);
+
+    expect(exec.exec).not.toHaveBeenCalled();
+  });
+
   test("buildDependencies", async () => {
     const stackCLI = new StackCLI([], false);
 

--- a/src/stack-cli.ts
+++ b/src/stack-cli.ts
@@ -57,6 +57,15 @@ export class StackCLI {
     return await this.exec(["setup"].concat(args));
   }
 
+  async installCompilerTools(tools: string[]): Promise<number> {
+    if (tools.length > 0) {
+      return await this.exec(["install", "--copy-compiler-tool"].concat(tools));
+    }
+
+    // No tools to install
+    return 0;
+  }
+
   async buildDependencies(args: string[]): Promise<number> {
     return await this.buildNoTest(["--dependencies-only"].concat(args));
   }


### PR DESCRIPTION
Since we moved to handling caching ourselves, and we store the cache at
the end of each step, installing compiler-tools separately from this
action would not include their build in said cache.

For example, if you intend to convert and upload coverage using `hcp-lcov`,
you can now do:

```yaml
- id: stack
  uses: freckle/stack-action@v5
  with:
    compiler-tools: hpc-lcov
    stack-build-arguments: --coverage

- run: stack --no-terminal exec -- hpc-lcov --file "$HPC_ROOT"/combined/all/all.tix
  env:
    HPC_ROOT: ${{ steps.stack.outputs.local-hpc-root }}

- uses: codecov/codecov-action@v2
  with:
    files: ./lcov.info
```

Before, you would have to install the tool yourself, and use something
like `stack-cache-action` to have its build cached.