### PR TITLE
Add -type f to generate-matrix default find(1) options

### DIFF
--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -105,13 +105,12 @@ jobs:
       fail-fast: false
 
     steps:
+      - uses: actions/checkout@v4
       - run: |
           if [[ -L '${{ matrix.stack-yaml }}' ]]; then
             echo "generate-matrix incorrectly included a symlink" >&2
             exit 1
           fi
-
-      - uses: actions/checkout@v4
       - uses: ./
         with:
           working-directory: example

--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -105,6 +105,12 @@ jobs:
       fail-fast: false
 
     steps:
+      - run: |
+          if [[ -L '${{ matrix.stack-yaml }}' ]]; then
+            echo "generate-matrix incorrectly included a symlink" >&2
+            exit 1
+          fi
+
       - uses: actions/checkout@v4
       - uses: ./
         with:

--- a/example/stack-link.yaml
+++ b/example/stack-link.yaml
@@ -1,0 +1,1 @@
+./stack.yaml

--- a/generate-matrix/action.yml
+++ b/generate-matrix/action.yml
@@ -8,7 +8,7 @@ inputs:
   find-options:
     description: "Arguments to find(1) stack-yaml files"
     required: true
-    default: "-maxdepth 1 -name 'stack*.yaml'"
+    default: "-type f -maxdepth 1 -name 'stack*.yaml'"
 outputs:
   stack-yamls:
     description: Version-sorted list of all files matching stack*.yaml


### PR DESCRIPTION
This ensures we only list regular files and not symbolic links. It may
be the case that a project symlinks `stack.yaml` to one of the specific
configurations. In such cases, only the actual files should generate
matrix elements. Generating one for `stack.yaml` would be redundant.

Projects that attach extra tasks (weeder, coverage) to only the
`stack.yaml` build should either not use a symlink, or adjust the `find`
input accordingly.
