### PR TITLE
fix(release): use app token for actions/checkout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,15 +11,15 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-
       - id: token
         uses: actions/create-github-app-token@v2
         with:
           app-id: ${{ vars.FRECKLE_AUTOMATION_APP_ID }}
           private-key: ${{ secrets.FRECKLE_AUTOMATION_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ steps.token.outputs.token }}
 
       - id: release
         uses: cycjimmy/semantic-release-action@v4


### PR DESCRIPTION
Since the release performs `git` commands, we have to ensure they are
also done using the app token, otherwise we won't have permission to
bypass branch protections or update workflows files.

For most release steps, the combination of `persist-credentials:false`,
and passing the right `GITHUB_TOKEN` to the semantic-release action
ensures this, but it appears `@semantic-release/git` simply calls `git`
commands within our checkout, which implicitly uses the original token,
so it fails:

    remote: error: GH013: Repository rule violations found for refs/heads/main.
    remote: Review all repository rules at https://github.com/freckle/stack-action/rules?ref=refs%2Fheads%2Fmain
    remote:
    remote: - Changes must be made through a pull request.
    remote:
    remote: - 3 of 3 required status checks are expected.
    remote:
    To https://github.com/freckle/stack-action.git
     ! [remote rejected] HEAD -> main (push declined due to repository rule violations)

To fix this, we pass the app token to `actions/checkout` too.

At that point, there's no reason not to persist them, since it's the
correct token we'd always want to use, so I removed that too.
