### PR TITLE
Potential fix for code scanning alert no. 15: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -1,5 +1,8 @@
 name: Example
 
+permissions:
+  contents: read
+
 on:
   pull_request:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/freckle/stack-action/security/code-scanning/15](https://github.com/freckle/stack-action/security/code-scanning/15)

To fix the issue, we will add a `permissions` block at the root level of the workflow to apply minimal permissions to all jobs. Based on the workflow's operations, the `contents: read` permission is sufficient for most jobs. If any job requires additional permissions, we will define a specific `permissions` block for that job.

1. Add a `permissions` block at the root level of the workflow with `contents: read`.
2. Review each job to determine if additional permissions are required. For example:
   - Jobs interacting with pull requests or issues might need `pull-requests: write` or `issues: write`.
   - Jobs downloading or uploading artifacts might need `actions: read` or `actions: write`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
