### PR TITLE
style: adopt a shared prettier config and reformat

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
           cache: pnpm
           node-version-file: ".nvmrc"
       - run: pnpm install --frozen-lockfile
+      - run: pnpm format-check
       - run: pnpm typecheck
       - run: pnpm lint
       - run: pnpm knip

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,18 @@
+{
+  "printWidth": 100,
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": false,
+  "singleQuote": true,
+  "quoteProps": "as-needed",
+  "jsxSingleQuote": false,
+  "trailingComma": "none",
+  "bracketSpacing": false,
+  "bracketSameLine": false,
+  "arrowParens": "avoid",
+  "requirePragma": false,
+  "insertPragma": false,
+  "proseWrap": "preserve",
+  "htmlWhitespaceSensitivity": "css",
+  "endOfLine": "auto"
+}

--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ This has been available since version 4 of this action.
 - `pnpm coverage` — Vitest with coverage, gated at the level the suite already reaches (see `vitest.config.js`; `main.ts` excluded: it drives real `stack` invocations, covered by the `example` workflow instead)
 - `pnpm typecheck` — `tsc --noEmit`, includes test files
 - `pnpm lint` — ESLint
+- `pnpm format` / `pnpm format-check` — Prettier
 - `pnpm knip` — unused files/dependencies/exports
 - CI runs all of the above on every PR; `.github/workflows/example.yml` then runs the built action end to end against `example/` across runners and resolvers
 

--- a/src/dirty-files.test.ts
+++ b/src/dirty-files.test.ts
@@ -1,62 +1,62 @@
-import { describe, expect, test } from "vitest";
+import {describe, expect, test} from 'vitest'
 
-import { parseGitStatus, isInterestingFile } from "./dirty-files.js";
+import {parseGitStatus, isInterestingFile} from './dirty-files.js'
 
-describe("parseGitStatus", () => {
-  test("parse file name, and filters untracked", () => {
+describe('parseGitStatus', () => {
+  test('parse file name, and filters untracked', () => {
     const paths = parseGitStatus(
       [
-        "A  staged-file.rb",
-        " M action.yml",
-        " M src/inputs.ts",
-        "?? src/new-file.ts",
-        " M src/path with spaces.md",
-      ].join("\n"),
-    );
+        'A  staged-file.rb',
+        ' M action.yml',
+        ' M src/inputs.ts',
+        '?? src/new-file.ts',
+        ' M src/path with spaces.md'
+      ].join('\n')
+    )
 
     expect(paths).toEqual([
-      "staged-file.rb",
-      "action.yml",
-      "src/inputs.ts",
-      "src/path with spaces.md",
-    ]);
-  });
+      'staged-file.rb',
+      'action.yml',
+      'src/inputs.ts',
+      'src/path with spaces.md'
+    ])
+  })
 
   const empties = [
-    ["empty", ""],
-    ["newline", "\n"],
-    ["spaces", " "],
-    ["spaces+newline", " \n"],
-  ];
+    ['empty', ''],
+    ['newline', '\n'],
+    ['spaces', ' '],
+    ['spaces+newline', ' \n']
+  ]
 
-  test.each(empties)("handles %s as no paths", (_arg, str) => {
-    expect(parseGitStatus(str)).toEqual([]);
-  });
-});
+  test.each(empties)('handles %s as no paths', (_arg, str) => {
+    expect(parseGitStatus(str)).toEqual([])
+  })
+})
 
-describe("isInterestingFile", () => {
+describe('isInterestingFile', () => {
   const interesting = [
-    "foo.cabal",
-    "bar.cabal",
-    "stack.yaml.lock",
-    "stack-lts20.yaml.lock",
-    "hie.yaml",
-    "example/hie.yaml",
-  ];
+    'foo.cabal',
+    'bar.cabal',
+    'stack.yaml.lock',
+    'stack-lts20.yaml.lock',
+    'hie.yaml',
+    'example/hie.yaml'
+  ]
 
-  test.each(interesting)("considers %p interesting", (path) => {
-    expect(isInterestingFile(path)).toBe(true);
-  });
+  test.each(interesting)('considers %p interesting', path => {
+    expect(isInterestingFile(path)).toBe(true)
+  })
 
   const uninteresting = [
-    "some-file.md",
-    "other file.txt",
-    "foo.cabal.lock",
-    "foo.yaml.lock2",
-    "routhie.yaml",
-  ];
+    'some-file.md',
+    'other file.txt',
+    'foo.cabal.lock',
+    'foo.yaml.lock2',
+    'routhie.yaml'
+  ]
 
-  test.each(uninteresting)("considers %p uninteresting", (path) => {
-    expect(isInterestingFile(path)).toBe(false);
-  });
-});
+  test.each(uninteresting)('considers %p uninteresting', path => {
+    expect(isInterestingFile(path)).toBe(false)
+  })
+})

--- a/src/dirty-files.ts
+++ b/src/dirty-files.ts
@@ -1,84 +1,78 @@
-import * as core from "@actions/core";
-import * as exec from "@actions/exec";
+import * as core from '@actions/core'
+import * as exec from '@actions/exec'
 
-export type OnDirtyFiles = "warn" | "error";
+export type OnDirtyFiles = 'warn' | 'error'
 
 export function parseOnDirtyFiles(input: string): OnDirtyFiles {
   switch (input) {
-    case "warn":
-    case "error":
-      return input as OnDirtyFiles;
+    case 'warn':
+    case 'error':
+      return input as OnDirtyFiles
     default:
-      throw new Error(
-        `Invalid on-dirty-files, must be warn or error, saw: ${input}`,
-      );
+      throw new Error(`Invalid on-dirty-files, must be warn or error, saw: ${input}`)
   }
 }
 
 export async function checkDirtyFiles(onDirtyFiles: OnDirtyFiles) {
-  const stdout = await readGitStatus();
-  const paths = parseGitStatus(stdout).filter(isInterestingFile);
+  const stdout = await readGitStatus()
+  const paths = parseGitStatus(stdout).filter(isInterestingFile)
 
   if (paths.length === 0) {
-    return;
+    return
   }
 
-  const message = `Build caused changes to ${paths.join(", ")}`;
+  const message = `Build caused changes to ${paths.join(', ')}`
 
   switch (onDirtyFiles) {
-    case "warn":
-      core.warning(message);
-      break;
-    case "error":
-      throw new Error(message);
+    case 'warn':
+      core.warning(message)
+      break
+    case 'error':
+      throw new Error(message)
   }
 }
 
 async function readGitStatus(): Promise<string> {
-  let stdout = "";
+  let stdout = ''
 
   const options: exec.ExecOptions = {
     listeners: {
       stdout: (data: Buffer) => {
-        stdout += data.toString();
-      },
+        stdout += data.toString()
+      }
     },
-    ignoreReturnCode: true,
-  };
+    ignoreReturnCode: true
+  }
 
-  await exec.exec("git", ["status", "--porcelain"], options);
+  await exec.exec('git', ['status', '--porcelain'], options)
 
-  return stdout;
+  return stdout
 }
 
 // Exported for testing
 export function parseGitStatus(stdout: string): string[] {
   return stdout
-    .split("\n")
-    .filter((path) => {
+    .split('\n')
+    .filter(path => {
       // We don't care about untracked files because users may be choosing not
       // to commit generated files -- in which case it showing up here is
       // expected.
-      return !path.startsWith("??");
+      return !path.startsWith('??')
     })
-    .map((path) => {
+    .map(path => {
       // Drop leading space, split on space, drop first column and rejoin
-      return path.replace(/^\s*/, "").split(/\s+/).slice(1).join(" ");
+      return path.replace(/^\s*/, '').split(/\s+/).slice(1).join(' ')
     })
-    .filter((path) => {
-      return path.trim() !== "";
-    });
+    .filter(path => {
+      return path.trim() !== ''
+    })
 }
 
-const INTERESTING_REGEXPS: RegExp[] = [
-  /^.*\.cabal$/,
-  /^.*\.yaml\.lock$/,
-  /^(.*\/)?hie\.yaml$/,
-];
+const INTERESTING_REGEXPS: RegExp[] = [/^.*\.cabal$/, /^.*\.yaml\.lock$/, /^(.*\/)?hie\.yaml$/]
 
 // Exported for testing
 export function isInterestingFile(path: string): boolean {
   return INTERESTING_REGEXPS.some((re, _index, _array) => {
-    return path.match(re);
-  });
+    return path.match(re)
+  })
 }

--- a/src/envsubst.test.ts
+++ b/src/envsubst.test.ts
@@ -1,36 +1,36 @@
-import { describe, expect, test } from "vitest";
+import {describe, expect, test} from 'vitest'
 
-import { envsubst } from "./envsubst.js";
+import {envsubst} from './envsubst.js'
 
-const HOME = process.env.HOME;
+const HOME = process.env.HOME
 
-describe("envsubst", () => {
-  test("known variables are replaced", () => {
-    expect(envsubst("Home is $HOME.")).toEqual(`Home is ${HOME}.`);
-  });
+describe('envsubst', () => {
+  test('known variables are replaced', () => {
+    expect(envsubst('Home is $HOME.')).toEqual(`Home is ${HOME}.`)
+  })
 
-  test("known variables with braces are replaced", () => {
-    expect(envsubst("Home is ${HOME}.")).toEqual(`Home is ${HOME}.`);
-  });
+  test('known variables with braces are replaced', () => {
+    expect(envsubst('Home is ${HOME}.')).toEqual(`Home is ${HOME}.`)
+  })
 
-  test("unknown variables are replaced by whitespace", () => {
-    expect(envsubst("Home is $XNOPE.")).toEqual("Home is .");
-  });
+  test('unknown variables are replaced by whitespace', () => {
+    expect(envsubst('Home is $XNOPE.')).toEqual('Home is .')
+  })
 
-  test("unknown variables with braces are replaced by whitespace", () => {
-    expect(envsubst("Home is ${XNOPE}.")).toEqual("Home is .");
-  });
+  test('unknown variables with braces are replaced by whitespace', () => {
+    expect(envsubst('Home is ${XNOPE}.')).toEqual('Home is .')
+  })
 
-  test("invalid braces are not replaced", () => {
-    expect(envsubst("Home is ${ HOME}.")).toEqual("Home is ${ HOME}.");
-    expect(envsubst("Home is ${HOME }.")).toEqual("Home is ${HOME }.");
-  });
+  test('invalid braces are not replaced', () => {
+    expect(envsubst('Home is ${ HOME}.')).toEqual('Home is ${ HOME}.')
+    expect(envsubst('Home is ${HOME }.')).toEqual('Home is ${HOME }.')
+  })
 
-  test("mismatched left brace is not replaced", () => {
-    expect(envsubst("Home is ${HOME.")).toEqual("Home is ${HOME.");
-  });
+  test('mismatched left brace is not replaced', () => {
+    expect(envsubst('Home is ${HOME.')).toEqual('Home is ${HOME.')
+  })
 
-  test("mismatched right brace is replaced before the brace", () => {
-    expect(envsubst("Home is $HOME}.")).toEqual(`Home is ${HOME}}.`);
-  });
-});
+  test('mismatched right brace is replaced before the brace', () => {
+    expect(envsubst('Home is $HOME}.')).toEqual(`Home is ${HOME}}.`)
+  })
+})

--- a/src/envsubst.ts
+++ b/src/envsubst.ts
@@ -1,10 +1,10 @@
-const REGEXP = new RegExp("\\$([A-Z_]+)|\\$\\{([A-Z_]+)\\}");
+const REGEXP = new RegExp('\\$([A-Z_]+)|\\$\\{([A-Z_]+)\\}')
 
 function replacer(_match: string, p1: string, p2: string): string {
-  return process.env[p2 ?? p1] ?? "";
+  return process.env[p2 ?? p1] ?? ''
 }
 
 /* replace environment variables in an input string, like envsubst(1) */
 export function envsubst(str: string): string {
-  return str.replace(REGEXP, replacer);
+  return str.replace(REGEXP, replacer)
 }

--- a/src/get-cache-keys.test.ts
+++ b/src/get-cache-keys.test.ts
@@ -1,13 +1,10 @@
-import { expect, test } from "vitest";
+import {expect, test} from 'vitest'
 
-import { getCacheKeys } from "./get-cache-keys.js";
+import {getCacheKeys} from './get-cache-keys.js'
 
-test("getCacheKeys", () => {
-  const keys = getCacheKeys(["prefix-os-compiler", "package", "source"]);
+test('getCacheKeys', () => {
+  const keys = getCacheKeys(['prefix-os-compiler', 'package', 'source'])
 
-  expect(keys.primaryKey).toEqual("prefix-os-compiler-package-source");
-  expect(keys.restoreKeys).toEqual([
-    "prefix-os-compiler-package-",
-    "prefix-os-compiler-",
-  ]);
-});
+  expect(keys.primaryKey).toEqual('prefix-os-compiler-package-source')
+  expect(keys.restoreKeys).toEqual(['prefix-os-compiler-package-', 'prefix-os-compiler-'])
+})

--- a/src/get-cache-keys.ts
+++ b/src/get-cache-keys.ts
@@ -1,18 +1,18 @@
 export type CacheKeys = {
-  primaryKey: string;
-  restoreKeys: string[];
-};
+  primaryKey: string
+  restoreKeys: string[]
+}
 
 export function getCacheKeys(parts: string[]): CacheKeys {
-  const primaryKey = parts.join("-");
-  const restoreKeys: string[] = [];
+  const primaryKey = parts.join('-')
+  const restoreKeys: string[] = []
 
-  let restoreParts = parts.slice(0, -1);
+  let restoreParts = parts.slice(0, -1)
 
   while (restoreParts.length > 0) {
-    restoreKeys.push(`${restoreParts.join("-")}-`);
-    restoreParts = restoreParts.slice(0, -1);
+    restoreKeys.push(`${restoreParts.join('-')}-`)
+    restoreParts = restoreParts.slice(0, -1)
   }
 
-  return { primaryKey, restoreKeys };
+  return {primaryKey, restoreKeys}
 }

--- a/src/hash-project.ts
+++ b/src/hash-project.ts
@@ -1,19 +1,19 @@
-import * as path from "path";
-import { hashFiles } from "@actions/glob";
+import * as path from 'path'
+import {hashFiles} from '@actions/glob'
 
-const ALL_SOURCES_PATTERNS = `**\n!**${path.sep}.stack-work\n!.git\n`;
-const BUILD_FILES_PATTERNS = `**${path.sep}package.yaml\n**${path.sep}*.cabal\n`;
+const ALL_SOURCES_PATTERNS = `**\n!**${path.sep}.stack-work\n!.git\n`
+const BUILD_FILES_PATTERNS = `**${path.sep}package.yaml\n**${path.sep}*.cabal\n`
 
 export type Hashes = {
-  snapshot: string;
-  package: string;
-  sources: string;
-};
+  snapshot: string
+  package: string
+  sources: string
+}
 
 export async function hashProject(stackYaml: string): Promise<Hashes> {
   return {
     snapshot: await hashFiles(stackYaml),
     package: await hashFiles(BUILD_FILES_PATTERNS),
-    sources: await hashFiles(ALL_SOURCES_PATTERNS),
-  };
+    sources: await hashFiles(ALL_SOURCES_PATTERNS)
+  }
 }

--- a/src/hie.ts
+++ b/src/hie.ts
@@ -1,49 +1,47 @@
-import * as fs from "fs";
-import * as core from "@actions/core";
+import * as fs from 'fs'
+import * as core from '@actions/core'
 
-import { StackCLI } from "./stack-cli.js"
+import {StackCLI} from './stack-cli.js'
 
-const HIE_YAML: string = "hie.yaml";
+const HIE_YAML: string = 'hie.yaml'
 
 export class GenHIE {
-  public readonly path: string;
+  public readonly path: string
 
-  private readonly stack: StackCLI;
-  private readonly exists: boolean;
+  private readonly stack: StackCLI
+  private readonly exists: boolean
 
   constructor(stack: StackCLI, path?: string) {
-    this.stack = stack;
-    this.path = path ? path : HIE_YAML;
-    this.exists = fs.existsSync(this.path);
+    this.stack = stack
+    this.path = path ? path : HIE_YAML
+    this.exists = fs.existsSync(this.path)
   }
 
   async install(): Promise<void> {
     if (this.exists) {
       try {
-        await this.stack.installCompilerTools(["implicit-hie"]);
+        await this.stack.installCompilerTools(['implicit-hie'])
       } catch {
-        core.warning(
-          `Failed to install implicit-hie, ${this.path} will not be maintained`,
-        );
+        core.warning(`Failed to install implicit-hie, ${this.path} will not be maintained`)
       }
     }
   }
 
   async generate(): Promise<void> {
     if (!this.exists) {
-      core.info(`Skipping, ${this.path} does not exist`);
-      return;
+      core.info(`Skipping, ${this.path} does not exist`)
+      return
     }
 
-    const installed = await this.stack.which("gen-hie");
+    const installed = await this.stack.which('gen-hie')
 
     if (!installed) {
-      core.info(`Skipping, implicit-hie was not successfully installed`);
-      return;
+      core.info(`Skipping, implicit-hie was not successfully installed`)
+      return
     }
 
-    core.info(`gen-hie --stack > ${this.path}`);
-    const yaml = await this.stack.read(["exec", "--", "gen-hie", "--stack"]);
-    fs.writeFileSync(this.path, yaml);
+    core.info(`gen-hie --stack > ${this.path}`)
+    const yaml = await this.stack.read(['exec', '--', 'gen-hie', '--stack'])
+    fs.writeFileSync(this.path, yaml)
   }
 }

--- a/src/inputs.ts
+++ b/src/inputs.ts
@@ -1,67 +1,64 @@
-import * as core from "@actions/core";
-import * as Shellwords from "shellwords-ts";
-import { envsubst } from "./envsubst.js"
-import { type OnDirtyFiles, parseOnDirtyFiles } from "./dirty-files.js"
+import * as core from '@actions/core'
+import * as Shellwords from 'shellwords-ts'
+import {envsubst} from './envsubst.js'
+import {type OnDirtyFiles, parseOnDirtyFiles} from './dirty-files.js'
 
 export type Inputs = {
-  workingDirectory: string | null;
-  test: boolean;
-  color: boolean;
-  stackArguments: string[];
-  stackSetupArguments: string[];
-  stackQueryArguments: string[];
-  stackBuildArgumentsDependencies: string[];
-  stackBuildArgumentsBuild: string[];
-  stackBuildArgumentsTest: string[];
-  cachePrefix: string;
-  cacheSaveAlways: boolean;
-  onDirtyFiles: OnDirtyFiles;
-  installStack: boolean;
-  upgradeStack: boolean;
-  compilerTools: string[];
+  workingDirectory: string | null
+  test: boolean
+  color: boolean
+  stackArguments: string[]
+  stackSetupArguments: string[]
+  stackQueryArguments: string[]
+  stackBuildArgumentsDependencies: string[]
+  stackBuildArgumentsBuild: string[]
+  stackBuildArgumentsTest: string[]
+  cachePrefix: string
+  cacheSaveAlways: boolean
+  onDirtyFiles: OnDirtyFiles
+  installStack: boolean
+  upgradeStack: boolean
+  compilerTools: string[]
 
   // Deprecated
-  stackYaml: string | null;
-};
+  stackYaml: string | null
+}
 
 export function getInputs(): Inputs {
   const getBuildArguments = (step: string): string[] => {
-    return getShellWordsInput("stack-build-arguments").concat(
-      getShellWordsInput(`stack-build-arguments-${step}`),
-    );
-  };
+    return getShellWordsInput('stack-build-arguments').concat(
+      getShellWordsInput(`stack-build-arguments-${step}`)
+    )
+  }
 
-  const rawOnDirtyFiles = core.getInput("on-dirty-files", { required: true });
+  const rawOnDirtyFiles = core.getInput('on-dirty-files', {required: true})
 
   return {
-    workingDirectory: getInputDefault("working-directory", null),
-    test: core.getBooleanInput("test"),
-    color: core.getBooleanInput("color"),
-    stackArguments: getShellWordsInput("stack-arguments"),
-    stackSetupArguments: getShellWordsInput("stack-setup-arguments"),
-    stackQueryArguments: getShellWordsInput("stack-query-arguments"),
-    stackBuildArgumentsDependencies: getBuildArguments("dependencies"),
-    stackBuildArgumentsBuild: getBuildArguments("build"),
-    stackBuildArgumentsTest: getBuildArguments("test"),
-    cachePrefix: core.getInput("cache-prefix"),
-    cacheSaveAlways: core.getBooleanInput("cache-save-always"),
+    workingDirectory: getInputDefault('working-directory', null),
+    test: core.getBooleanInput('test'),
+    color: core.getBooleanInput('color'),
+    stackArguments: getShellWordsInput('stack-arguments'),
+    stackSetupArguments: getShellWordsInput('stack-setup-arguments'),
+    stackQueryArguments: getShellWordsInput('stack-query-arguments'),
+    stackBuildArgumentsDependencies: getBuildArguments('dependencies'),
+    stackBuildArgumentsBuild: getBuildArguments('build'),
+    stackBuildArgumentsTest: getBuildArguments('test'),
+    cachePrefix: core.getInput('cache-prefix'),
+    cacheSaveAlways: core.getBooleanInput('cache-save-always'),
     onDirtyFiles: parseOnDirtyFiles(rawOnDirtyFiles),
-    installStack: core.getBooleanInput("install-stack"),
-    upgradeStack: core.getBooleanInput("upgrade-stack"),
-    compilerTools: core.getMultilineInput("compiler-tools"),
-    stackYaml: getInputDefault("stack-yaml", null),
-  };
+    installStack: core.getBooleanInput('install-stack'),
+    upgradeStack: core.getBooleanInput('upgrade-stack'),
+    compilerTools: core.getMultilineInput('compiler-tools'),
+    stackYaml: getInputDefault('stack-yaml', null)
+  }
 }
 
 function getInputDefault<T>(name: string, d: T): string | T {
-  const raw = core.getInput(name, { trimWhitespace: true });
-  return raw === "" ? d : raw;
+  const raw = core.getInput(name, {trimWhitespace: true})
+  return raw === '' ? d : raw
 }
 
-function getShellWordsInput(
-  name: string,
-  options?: core.InputOptions,
-): string[] {
-  const raw = core.getMultilineInput(name, options).join(" ");
-  return Shellwords.split(raw).map(envsubst);
+function getShellWordsInput(name: string, options?: core.InputOptions): string[] {
+  const raw = core.getMultilineInput(name, options).join(' ')
+  return Shellwords.split(raw).map(envsubst)
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,89 +1,89 @@
-import * as core from "@actions/core";
+import * as core from '@actions/core'
 
-import { checkDirtyFiles } from "./dirty-files.js"
-import { StackCLI } from "./stack-cli.js"
-import { getCacheKeys } from "./get-cache-keys.js"
-import { hashProject } from "./hash-project.js"
-import { getInputs } from "./inputs.js"
-import { readStackYamlSync, getStackDirectories } from "./stack-yaml.js"
-import { DEFAULT_CACHE_OPTIONS, withCache } from "./with-cache.js"
-import { GenHIE } from "./hie.js"
+import {checkDirtyFiles} from './dirty-files.js'
+import {StackCLI} from './stack-cli.js'
+import {getCacheKeys} from './get-cache-keys.js'
+import {hashProject} from './hash-project.js'
+import {getInputs} from './inputs.js'
+import {readStackYamlSync, getStackDirectories} from './stack-yaml.js'
+import {DEFAULT_CACHE_OPTIONS, withCache} from './with-cache.js'
+import {GenHIE} from './hie.js'
 
 async function run() {
   try {
-    const inputs = getInputs();
+    const inputs = getInputs()
 
     if (inputs.color) {
-      inputs.stackArguments.unshift("--color=always");
+      inputs.stackArguments.unshift('--color=always')
     }
 
     if (inputs.workingDirectory) {
-      core.debug(`Change directory: ${inputs.workingDirectory}`);
-      process.chdir(inputs.workingDirectory);
+      core.debug(`Change directory: ${inputs.workingDirectory}`)
+      process.chdir(inputs.workingDirectory)
     }
 
     if (inputs.stackYaml) {
       core.warning(
-        "inputs.stack-yaml is deprecated. Set env.STACK_YAML or use inputs.stack-arguments instead.",
-      );
+        'inputs.stack-yaml is deprecated. Set env.STACK_YAML or use inputs.stack-arguments instead.'
+      )
 
       // Maintain original behavior for now
-      inputs.stackArguments.unshift(inputs.stackYaml);
-      inputs.stackArguments.unshift("--stack-yaml");
+      inputs.stackArguments.unshift(inputs.stackYaml)
+      inputs.stackArguments.unshift('--stack-yaml')
     }
 
-    const stack = new StackCLI(inputs.stackArguments, core.isDebug());
-    const genHIE = new GenHIE(stack);
+    const stack = new StackCLI(inputs.stackArguments, core.isDebug())
+    const genHIE = new GenHIE(stack)
 
-    await core.group("Install/upgrade stack", async () => {
-      const installed = await stack.installed();
+    await core.group('Install/upgrade stack', async () => {
+      const installed = await stack.installed()
 
       if (installed) {
         if (inputs.upgradeStack) {
-          core.info("Upgrading stack");
-          await stack.upgrade();
+          core.info('Upgrading stack')
+          await stack.upgrade()
         }
       } else {
         if (inputs.installStack) {
-          core.info("Installing stack");
-          await stack.install();
+          core.info('Installing stack')
+          await stack.install()
         } else {
           throw new Error(
             [
-              "The executable stack is not present on $PATH",
-              "Make sure it is installed in a preceding step, or use",
-              "`install-stack: true` to have it installed for you.",
-            ].join("\n"),
-          );
+              'The executable stack is not present on $PATH',
+              'Make sure it is installed in a preceding step, or use',
+              '`install-stack: true` to have it installed for you.'
+            ].join('\n')
+          )
         }
       }
-    });
+    })
 
-    const hashes = await core.group("Calculate hashes", async () => {
-      const hashes = await hashProject(stack.config);
-      core.info(`Snapshot: ${hashes.snapshot}`);
-      core.info(`Packages: ${hashes.package}`);
-      core.info(`Sources: ${hashes.sources}`);
-      return hashes;
-    });
+    const hashes = await core.group('Calculate hashes', async () => {
+      const hashes = await hashProject(stack.config)
+      core.info(`Snapshot: ${hashes.snapshot}`)
+      core.info(`Packages: ${hashes.package}`)
+      core.info(`Sources: ${hashes.sources}`)
+      return hashes
+    })
 
-    const { stackYaml, stackDirectories } = await core.group(
-      "Determine stack directories",
+    const {stackYaml, stackDirectories} = await core.group(
+      'Determine stack directories',
       async () => {
-        const stackYaml = readStackYamlSync(stack.config);
-        const stackDirectories = await getStackDirectories(stackYaml, stack);
+        const stackYaml = readStackYamlSync(stack.config)
+        const stackDirectories = await getStackDirectories(stackYaml, stack)
 
         core.info(
           [
             `Stack root: ${stackDirectories.stackRoot}`,
             `Stack programs: ${stackDirectories.stackPrograms}`,
-            `Stack works:\n - ${stackDirectories.stackWorks.join("\n - ")}`,
-          ].join("\n"),
-        );
+            `Stack works:\n - ${stackDirectories.stackWorks.join('\n - ')}`
+          ].join('\n')
+        )
 
-        return { stackYaml, stackDirectories };
-      },
-    );
+        return {stackYaml, stackDirectories}
+      }
+    )
 
     // Can't use compiler here because stack-query requires setting up the Stack
     // environment, installing GHC, etc. And we never want to do that outside of
@@ -92,95 +92,90 @@ async function run() {
     // stack.yaml file in use.
     const cachePrefix = `${inputs.cachePrefix}${process.platform}${process.arch}/${
       stack.resolver ?? stackYaml.resolver
-    }`;
+    }`
 
-    await core.group("Setup and install dependencies", async () => {
-      const { stackRoot, stackPrograms, stackWorks } = stackDirectories;
+    await core.group('Setup and install dependencies', async () => {
+      const {stackRoot, stackPrograms, stackWorks} = stackDirectories
 
       await withCache(
         [stackRoot, stackPrograms].concat(stackWorks),
         getCacheKeys([`${cachePrefix}/deps`, hashes.snapshot, hashes.package]),
         async () => {
-          await stack.setup(inputs.stackSetupArguments);
-          await stack.buildDependencies(inputs.stackBuildArgumentsDependencies);
-          await stack.installCompilerTools(inputs.compilerTools);
-          await genHIE.install();
+          await stack.setup(inputs.stackSetupArguments)
+          await stack.buildDependencies(inputs.stackBuildArgumentsDependencies)
+          await stack.installCompilerTools(inputs.compilerTools)
+          await genHIE.install()
         },
         {
           ...DEFAULT_CACHE_OPTIONS,
-          saveOnError: inputs.cacheSaveAlways,
-        },
-      );
-    });
+          saveOnError: inputs.cacheSaveAlways
+        }
+      )
+    })
 
-    await core.group("Build", async () => {
+    await core.group('Build', async () => {
       await withCache(
         stackDirectories.stackWorks,
-        getCacheKeys([
-          `${cachePrefix}/build`,
-          hashes.snapshot,
-          hashes.package,
-          hashes.sources,
-        ]),
+        getCacheKeys([`${cachePrefix}/build`, hashes.snapshot, hashes.package, hashes.sources]),
         async () => {
-          await stack.buildNoTest(inputs.stackBuildArgumentsBuild);
+          await stack.buildNoTest(inputs.stackBuildArgumentsBuild)
         },
         {
           ...DEFAULT_CACHE_OPTIONS,
           skipOnHit: false, // always Build
-          saveOnError: inputs.cacheSaveAlways,
-        },
-      );
-    });
+          saveOnError: inputs.cacheSaveAlways
+        }
+      )
+    })
 
     await core.group(`Maintain ${genHIE.path}`, async () => {
-      await genHIE.generate();
-    });
+      await genHIE.generate()
+    })
 
-    await core.group("Check for dirty files", async () => {
-      await checkDirtyFiles(inputs.onDirtyFiles);
-    });
+    await core.group('Check for dirty files', async () => {
+      await checkDirtyFiles(inputs.onDirtyFiles)
+    })
 
     if (inputs.test) {
-      await core.group("Test", async () => {
-        await stack.buildTest(inputs.stackBuildArgumentsTest);
-      });
+      await core.group('Test', async () => {
+        await stack.buildTest(inputs.stackBuildArgumentsTest)
+      })
     }
 
-    await core.group("Set outputs", async () => {
-      const stackQuery = await stack.query();
-      const compiler = stackQuery.compiler.actual;
-      const compilerVersion = compiler.replace(/^ghc-/, "");
+    await core.group('Set outputs', async () => {
+      const stackQuery = await stack.query()
+      const compiler = stackQuery.compiler.actual
+      const compilerVersion = compiler.replace(/^ghc-/, '')
 
-      core.info("Setting query-compiler outputs");
-      core.setOutput("compiler", compiler);
-      core.setOutput("compiler-version", compilerVersion);
+      core.info('Setting query-compiler outputs')
+      core.setOutput('compiler', compiler)
+      core.setOutput('compiler-version', compilerVersion)
 
-      const stackPath = await stack.path();
+      const stackPath = await stack.path()
 
-      core.info("Setting stack-path outputs");
+      core.info('Setting stack-path outputs')
       for (const k in stackPath) {
-        const v = stackPath[k];
-        core.debug(`Setting stack-path output: ${k}=${v}`);
-        core.setOutput(k, v);
+        const v = stackPath[k]
+        core.debug(`Setting stack-path output: ${k}=${v}`)
+        core.setOutput(k, v)
       }
-    });
+    })
     // https://github.com/actions/cache/blob/0c45773b623bea8c8e75f6c82b208c3cf94ea4f9/src/restoreImpl.ts#L99-L106
-    process.exit(0);
+    process.exit(0)
   } catch (error) {
     if (error instanceof Error) {
-      core.error(error);
-      core.setFailed(error.message);
-    } else if (typeof error === "string") {
-      core.error(error);
-      core.setFailed(error);
+      core.error(error)
+      core.setFailed(error.message)
+    } else if (typeof error === 'string') {
+      core.error(error)
+      core.setFailed(error)
     } else {
-      core.error("Non-Error exception");
-      core.setFailed("Non-Error exception");
+      core.error('Non-Error exception')
+      core.setFailed('Non-Error exception')
     }
     // https://github.com/actions/cache/blob/0c45773b623bea8c8e75f6c82b208c3cf94ea4f9/src/restoreImpl.ts#L88
-    process.exit(1);
+    process.exit(1)
   }
 }
 
-run();
+run()

--- a/src/parse-stack-path.test.ts
+++ b/src/parse-stack-path.test.ts
@@ -1,37 +1,37 @@
-import { expect, test } from "vitest";
+import {expect, test} from 'vitest'
 
-import { parseStackPath } from "./parse-stack-path.js";
+import {parseStackPath} from './parse-stack-path.js'
 
 const EXAMPLE = [
-  "snapshot-doc-root: /home/patrick/.stack/snapshots/x86_64-linux-tinfo6/0dd02c1d8a380045321779c4567c2aa8873910743eac342f72d56f3d26881028/9.2.7/doc",
-  "local-doc-root: /home/patrick/code/freckle/megarepo/backend/.stack-work/install/x86_64-linux-tinfo6/0dd02c1d8a380045321779c4567c2aa8873910743eac342f72d56f3d26881028/9.2.7/doc",
-  "local-hoogle-root: /home/patrick/code/freckle/megarepo/backend/.stack-work/hoogle/x86_64-linux-tinfo6/0dd02c1d8a380045321779c4567c2aa8873910743eac342f72d56f3d26881028/9.2.7",
-  "stack-root: /home/patrick/.stack",
-  "global-config: /home/patrick/.stack/config.yaml",
-  "project-root: /home/patrick/code/freckle/megarepo/backend",
-  "config-location: /home/patrick/code/freckle/megarepo/backend/stack.yaml",
-  "bin-path: /home/patrick/.stack/snapshots/x86_64-linux-tinfo6/7eed7816433ae7cc7801479e88c42a76f77602f2a5c39ec077837318841a4e18/9.2.7/bin:/home/patrick/.stack/compiler-tools/x86_64-linux-tinfo6/ghc-9.2.7/bin:/home/patrick/.stack/programs/x86_64-linux/ghc-tinfo6-9.2.7/bin:/home/patrick/.nvm/versions/node/v16.13.1/bin:/home/patrick/.local/bin:/home/patrick/.local/share/gem/ruby/3.0.0/bin:/home/patrick/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/lib/jvm/default/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl",
-  "programs: /home/patrick/.stack/programs/x86_64-linux",
-  "compiler-exe: /home/patrick/.stack/programs/x86_64-linux/ghc-tinfo6-9.2.7/bin/ghc-9.2.7",
-  "compiler-bin: /home/patrick/.stack/programs/x86_64-linux/ghc-tinfo6-9.2.7/bin",
-  "compiler-tools-bin: /home/patrick/.stack/compiler-tools/x86_64-linux-tinfo6/ghc-9.2.7/bin",
-  "local-bin: /home/patrick/.local/bin",
-  "extra-include-dirs:",
-  "extra-library-dirs:",
-  "snapshot-pkg-db: /home/patrick/.stack/snapshots/x86_64-linux-tinfo6/7eed7816433ae7cc7801479e88c42a76f77602f2a5c39ec077837318841a4e18/9.2.7/pkgdb",
-  "local-pkg-db: /home/patrick/code/freckle/megarepo/backend/.stack-work/install/x86_64-linux-tinfo6/7eed7816433ae7cc7801479e88c42a76f77602f2a5c39ec077837318841a4e18/9.2.7/pkgdb",
-  "global-pkg-db: /home/patrick/.stack/programs/x86_64-linux/ghc-tinfo6-9.2.7/lib/ghc-9.2.7/package.conf.d",
-  "ghc-package-path: /home/patrick/code/freckle/megarepo/backend/.stack-work/install/x86_64-linux-tinfo6/7eed7816433ae7cc7801479e88c42a76f77602f2a5c39ec077837318841a4e18/9.2.7/pkgdb:/home/patrick/.stack/snapshots/x86_64-linux-tinfo6/7eed7816433ae7cc7801479e88c42a76f77602f2a5c39ec077837318841a4e18/9.2.7/pkgdb:/home/patrick/.stack/programs/x86_64-linux/ghc-tinfo6-9.2.7/lib/ghc-9.2.7/package.conf.d",
-  "snapshot-install-root: /home/patrick/.stack/snapshots/x86_64-linux-tinfo6/7eed7816433ae7cc7801479e88c42a76f77602f2a5c39ec077837318841a4e18/9.2.7",
-  "local-install-root: /home/patrick/code/freckle/megarepo/backend/.stack-work/install/x86_64-linux-tinfo6/7eed7816433ae7cc7801479e88c42a76f77602f2a5c39ec077837318841a4e18/9.2.7",
-  "dist-dir: .stack-work/dist/x86_64-linux-tinfo6/ghc-9.2.7",
-  "local-hpc-root: /home/patrick/code/freckle/megarepo/backend/.stack-work/install/x86_64-linux-tinfo6/7eed7816433ae7cc7801479e88c42a76f77602f2a5c39ec077837318841a4e18/9.2.7/hpc",
-].join("\n");
+  'snapshot-doc-root: /home/patrick/.stack/snapshots/x86_64-linux-tinfo6/0dd02c1d8a380045321779c4567c2aa8873910743eac342f72d56f3d26881028/9.2.7/doc',
+  'local-doc-root: /home/patrick/code/freckle/megarepo/backend/.stack-work/install/x86_64-linux-tinfo6/0dd02c1d8a380045321779c4567c2aa8873910743eac342f72d56f3d26881028/9.2.7/doc',
+  'local-hoogle-root: /home/patrick/code/freckle/megarepo/backend/.stack-work/hoogle/x86_64-linux-tinfo6/0dd02c1d8a380045321779c4567c2aa8873910743eac342f72d56f3d26881028/9.2.7',
+  'stack-root: /home/patrick/.stack',
+  'global-config: /home/patrick/.stack/config.yaml',
+  'project-root: /home/patrick/code/freckle/megarepo/backend',
+  'config-location: /home/patrick/code/freckle/megarepo/backend/stack.yaml',
+  'bin-path: /home/patrick/.stack/snapshots/x86_64-linux-tinfo6/7eed7816433ae7cc7801479e88c42a76f77602f2a5c39ec077837318841a4e18/9.2.7/bin:/home/patrick/.stack/compiler-tools/x86_64-linux-tinfo6/ghc-9.2.7/bin:/home/patrick/.stack/programs/x86_64-linux/ghc-tinfo6-9.2.7/bin:/home/patrick/.nvm/versions/node/v16.13.1/bin:/home/patrick/.local/bin:/home/patrick/.local/share/gem/ruby/3.0.0/bin:/home/patrick/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/lib/jvm/default/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl',
+  'programs: /home/patrick/.stack/programs/x86_64-linux',
+  'compiler-exe: /home/patrick/.stack/programs/x86_64-linux/ghc-tinfo6-9.2.7/bin/ghc-9.2.7',
+  'compiler-bin: /home/patrick/.stack/programs/x86_64-linux/ghc-tinfo6-9.2.7/bin',
+  'compiler-tools-bin: /home/patrick/.stack/compiler-tools/x86_64-linux-tinfo6/ghc-9.2.7/bin',
+  'local-bin: /home/patrick/.local/bin',
+  'extra-include-dirs:',
+  'extra-library-dirs:',
+  'snapshot-pkg-db: /home/patrick/.stack/snapshots/x86_64-linux-tinfo6/7eed7816433ae7cc7801479e88c42a76f77602f2a5c39ec077837318841a4e18/9.2.7/pkgdb',
+  'local-pkg-db: /home/patrick/code/freckle/megarepo/backend/.stack-work/install/x86_64-linux-tinfo6/7eed7816433ae7cc7801479e88c42a76f77602f2a5c39ec077837318841a4e18/9.2.7/pkgdb',
+  'global-pkg-db: /home/patrick/.stack/programs/x86_64-linux/ghc-tinfo6-9.2.7/lib/ghc-9.2.7/package.conf.d',
+  'ghc-package-path: /home/patrick/code/freckle/megarepo/backend/.stack-work/install/x86_64-linux-tinfo6/7eed7816433ae7cc7801479e88c42a76f77602f2a5c39ec077837318841a4e18/9.2.7/pkgdb:/home/patrick/.stack/snapshots/x86_64-linux-tinfo6/7eed7816433ae7cc7801479e88c42a76f77602f2a5c39ec077837318841a4e18/9.2.7/pkgdb:/home/patrick/.stack/programs/x86_64-linux/ghc-tinfo6-9.2.7/lib/ghc-9.2.7/package.conf.d',
+  'snapshot-install-root: /home/patrick/.stack/snapshots/x86_64-linux-tinfo6/7eed7816433ae7cc7801479e88c42a76f77602f2a5c39ec077837318841a4e18/9.2.7',
+  'local-install-root: /home/patrick/code/freckle/megarepo/backend/.stack-work/install/x86_64-linux-tinfo6/7eed7816433ae7cc7801479e88c42a76f77602f2a5c39ec077837318841a4e18/9.2.7',
+  'dist-dir: .stack-work/dist/x86_64-linux-tinfo6/ghc-9.2.7',
+  'local-hpc-root: /home/patrick/code/freckle/megarepo/backend/.stack-work/install/x86_64-linux-tinfo6/7eed7816433ae7cc7801479e88c42a76f77602f2a5c39ec077837318841a4e18/9.2.7/hpc'
+].join('\n')
 
-test("parseStackPath", () => {
-  const stackPath = parseStackPath(EXAMPLE);
+test('parseStackPath', () => {
+  const stackPath = parseStackPath(EXAMPLE)
 
   // Test one non-null and one nullable
-  expect(stackPath["stack-root"]).toBe("/home/patrick/.stack");
-  expect(stackPath["extra-include-dirs"]).toBeNull();
-});
+  expect(stackPath['stack-root']).toBe('/home/patrick/.stack')
+  expect(stackPath['extra-include-dirs']).toBeNull()
+})

--- a/src/parse-stack-path.ts
+++ b/src/parse-stack-path.ts
@@ -1,9 +1,9 @@
-import * as yaml from "js-yaml";
+import * as yaml from 'js-yaml'
 
 export type StackPath = {
-  [key: string]: string | null;
-};
+  [key: string]: string | null
+}
 
 export function parseStackPath(stdout: string): StackPath {
-  return yaml.load(stdout) as StackPath;
+  return yaml.load(stdout) as StackPath
 }

--- a/src/parse-stack-query.test.ts
+++ b/src/parse-stack-query.test.ts
@@ -1,25 +1,25 @@
-import { expect, test } from "vitest";
+import {expect, test} from 'vitest'
 
-import { parseStackQuery } from "./parse-stack-query.js";
+import {parseStackQuery} from './parse-stack-query.js'
 
 const EXAMPLE = [
-  "compiler:",
-  "  actual: ghc-9.2.7",
-  "  wanted: ghc-9.2.7",
-  "locals:",
-  "  core:",
-  "    path: /home/patrick/code/freckle/megarepo/backend/core/",
-  "    version: 0.0.0",
-  "  entities:",
-  "    path: /home/patrick/code/freckle/megarepo/backend/entities/",
-  "    version: 0.0.0",
-  "  fancy-api:",
-  "    path: /home/patrick/code/freckle/megarepo/backend/fancy-api/",
-  "    version: 0.0.0",
-].join("\n");
+  'compiler:',
+  '  actual: ghc-9.2.7',
+  '  wanted: ghc-9.2.7',
+  'locals:',
+  '  core:',
+  '    path: /home/patrick/code/freckle/megarepo/backend/core/',
+  '    version: 0.0.0',
+  '  entities:',
+  '    path: /home/patrick/code/freckle/megarepo/backend/entities/',
+  '    version: 0.0.0',
+  '  fancy-api:',
+  '    path: /home/patrick/code/freckle/megarepo/backend/fancy-api/',
+  '    version: 0.0.0'
+].join('\n')
 
-test("parseStackQuery", () => {
-  const stackQuery = parseStackQuery(EXAMPLE);
-  expect(stackQuery.compiler.actual).toBe("ghc-9.2.7");
-  expect(stackQuery.compiler.wanted).toBe("ghc-9.2.7");
-});
+test('parseStackQuery', () => {
+  const stackQuery = parseStackQuery(EXAMPLE)
+  expect(stackQuery.compiler.actual).toBe('ghc-9.2.7')
+  expect(stackQuery.compiler.wanted).toBe('ghc-9.2.7')
+})

--- a/src/parse-stack-query.ts
+++ b/src/parse-stack-query.ts
@@ -1,14 +1,14 @@
-import * as yaml from "js-yaml";
+import * as yaml from 'js-yaml'
 
 export type StackQuery = {
-  compiler: Compiler;
-};
+  compiler: Compiler
+}
 
 type Compiler = {
-  actual: string;
-  wanted: string;
-};
+  actual: string
+  wanted: string
+}
 
 export function parseStackQuery(stdout: string): StackQuery {
-  return yaml.load(stdout) as StackQuery;
+  return yaml.load(stdout) as StackQuery
 }

--- a/src/stack-cli.test.ts
+++ b/src/stack-cli.test.ts
@@ -1,145 +1,108 @@
-import { ExecOptions } from "@actions/exec";
-import { describe, expect, test, vi } from "vitest";
+import {ExecOptions} from '@actions/exec'
+import {describe, expect, test, vi} from 'vitest'
 
-import { ExecDelegate, StackCLI } from "./stack-cli.js";
+import {ExecDelegate, StackCLI} from './stack-cli.js'
 
 const exec: ExecDelegate = {
-  exec: vi.fn((_command: string, _args: string[], _options?: ExecOptions) =>
-    Promise.resolve(0),
-  ),
-};
+  exec: vi.fn((_command: string, _args: string[], _options?: ExecOptions) => Promise.resolve(0))
+}
 
-describe("StackCLI", () => {
-  test("Respects --resolver given", async () => {
-    const stackCLI = new StackCLI(["--resolver", "lts"], false, exec);
+describe('StackCLI', () => {
+  test('Respects --resolver given', async () => {
+    const stackCLI = new StackCLI(['--resolver', 'lts'], false, exec)
 
-    await stackCLI.setup([]);
+    await stackCLI.setup([])
 
     expect(exec.exec).toHaveBeenCalledWith(
-      "stack",
-      ["--resolver", "lts", "setup"],
-      undefined, // ExecOptions
-    );
-  });
+      'stack',
+      ['--resolver', 'lts', 'setup'],
+      undefined // ExecOptions
+    )
+  })
 
-  test("Adds --resolver nightly", async () => {
-    const stackCLI = new StackCLI(
-      ["--stack-yaml", "sub/stack-nightly.yaml"],
-      false,
-      exec,
-    );
+  test('Adds --resolver nightly', async () => {
+    const stackCLI = new StackCLI(['--stack-yaml', 'sub/stack-nightly.yaml'], false, exec)
 
-    await stackCLI.setup([]);
+    await stackCLI.setup([])
 
     expect(exec.exec).toHaveBeenCalledWith(
-      "stack",
-      [
-        "--stack-yaml",
-        "sub/stack-nightly.yaml",
-        "--resolver",
-        "nightly",
-        "setup",
-      ],
-      undefined, // ExecOptions
-    );
-  });
+      'stack',
+      ['--stack-yaml', 'sub/stack-nightly.yaml', '--resolver', 'nightly', 'setup'],
+      undefined // ExecOptions
+    )
+  })
 
   test("Doesn't add --resolver nightly if given", async () => {
     const stackCLI = new StackCLI(
-      [
-        "--stack-yaml",
-        "sub/stack-nightly.yaml",
-        "--resolver",
-        "nightly-20240201",
-      ],
+      ['--stack-yaml', 'sub/stack-nightly.yaml', '--resolver', 'nightly-20240201'],
       false,
-      exec,
-    );
+      exec
+    )
 
-    await stackCLI.setup([]);
-
-    expect(exec.exec).toHaveBeenCalledWith(
-      "stack",
-      [
-        "--stack-yaml",
-        "sub/stack-nightly.yaml",
-        "--resolver",
-        "nightly-20240201",
-        "setup",
-      ],
-      undefined, // ExecOptions
-    );
-  });
-
-  test("installCompilerTools", async () => {
-    const stackCLI = new StackCLI([], false, exec);
-    await stackCLI.installCompilerTools(["hlint", "weeder"]);
+    await stackCLI.setup([])
 
     expect(exec.exec).toHaveBeenCalledWith(
-      "stack",
-      ["install", "--copy-compiler-tool", "hlint", "weeder"],
-      undefined,
-    );
-  });
+      'stack',
+      ['--stack-yaml', 'sub/stack-nightly.yaml', '--resolver', 'nightly-20240201', 'setup'],
+      undefined // ExecOptions
+    )
+  })
 
-  test("installCompilerTools with empty arguments", async () => {
-    const stackCLI = new StackCLI([], false, exec);
-    await stackCLI.installCompilerTools([]);
-
-    expect(exec.exec).not.toHaveBeenCalled();
-  });
-
-  test("buildDependencies", async () => {
-    const stackCLI = new StackCLI([], false, exec);
-
-    await stackCLI.buildDependencies(["--coverage"]);
+  test('installCompilerTools', async () => {
+    const stackCLI = new StackCLI([], false, exec)
+    await stackCLI.installCompilerTools(['hlint', 'weeder'])
 
     expect(exec.exec).toHaveBeenCalledWith(
-      "stack",
-      [
-        "build",
-        "--test",
-        "--no-run-tests",
-        "--dependencies-only",
-        "--coverage",
-      ],
-      undefined,
-    );
-  });
+      'stack',
+      ['install', '--copy-compiler-tool', 'hlint', 'weeder'],
+      undefined
+    )
+  })
 
-  test("buildNoTest", async () => {
-    const stackCLI = new StackCLI([], false, exec);
+  test('installCompilerTools with empty arguments', async () => {
+    const stackCLI = new StackCLI([], false, exec)
+    await stackCLI.installCompilerTools([])
 
-    await stackCLI.buildNoTest(["--coverage"]);
+    expect(exec.exec).not.toHaveBeenCalled()
+  })
 
-    expect(exec.exec).toHaveBeenCalledWith(
-      "stack",
-      ["build", "--test", "--no-run-tests", "--coverage"],
-      undefined,
-    );
-  });
+  test('buildDependencies', async () => {
+    const stackCLI = new StackCLI([], false, exec)
 
-  test("buildTest", async () => {
-    const stackCLI = new StackCLI([], false, exec);
-
-    await stackCLI.buildTest(["--coverage"]);
+    await stackCLI.buildDependencies(['--coverage'])
 
     expect(exec.exec).toHaveBeenCalledWith(
-      "stack",
-      ["build", "--test", "--coverage"],
-      undefined,
-    );
-  });
+      'stack',
+      ['build', '--test', '--no-run-tests', '--dependencies-only', '--coverage'],
+      undefined
+    )
+  })
 
-  test("build", async () => {
-    const stackCLI = new StackCLI([], false, exec);
+  test('buildNoTest', async () => {
+    const stackCLI = new StackCLI([], false, exec)
 
-    await stackCLI.build(["--coverage"]);
+    await stackCLI.buildNoTest(['--coverage'])
 
     expect(exec.exec).toHaveBeenCalledWith(
-      "stack",
-      ["build", "--coverage"],
-      undefined,
-    );
-  });
-});
+      'stack',
+      ['build', '--test', '--no-run-tests', '--coverage'],
+      undefined
+    )
+  })
+
+  test('buildTest', async () => {
+    const stackCLI = new StackCLI([], false, exec)
+
+    await stackCLI.buildTest(['--coverage'])
+
+    expect(exec.exec).toHaveBeenCalledWith('stack', ['build', '--test', '--coverage'], undefined)
+  })
+
+  test('build', async () => {
+    const stackCLI = new StackCLI([], false, exec)
+
+    await stackCLI.build(['--coverage'])
+
+    expect(exec.exec).toHaveBeenCalledWith('stack', ['build', '--coverage'], undefined)
+  })
+})

--- a/src/stack-cli.ts
+++ b/src/stack-cli.ts
@@ -1,150 +1,142 @@
-import * as fs from "fs";
-import * as path from "path";
-import { devNull } from "os";
-import type { ExecOptions } from "@actions/exec";
-import * as realExec from "@actions/exec";
+import * as fs from 'fs'
+import * as path from 'path'
+import {devNull} from 'os'
+import type {ExecOptions} from '@actions/exec'
+import * as realExec from '@actions/exec'
 
-import type { StackPath } from "./parse-stack-path.js";
-import { parseStackPath } from "./parse-stack-path.js";
-import type { StackQuery } from "./parse-stack-query.js";
-import { parseStackQuery } from "./parse-stack-query.js";
+import type {StackPath} from './parse-stack-path.js'
+import {parseStackPath} from './parse-stack-path.js'
+import type {StackQuery} from './parse-stack-query.js'
+import {parseStackQuery} from './parse-stack-query.js'
 
 export interface ExecDelegate {
-  exec: (
-    command: string,
-    args: string[],
-    options?: ExecOptions,
-  ) => Promise<number>;
+  exec: (command: string, args: string[], options?: ExecOptions) => Promise<number>
 }
 
 export class StackCLI {
-  public config: string;
-  public resolver: string | null;
+  public config: string
+  public resolver: string | null
 
-  private debug: boolean;
-  private globalArgs: string[];
-  private execImpl: ExecDelegate;
+  private debug: boolean
+  private globalArgs: string[]
+  private execImpl: ExecDelegate
 
   constructor(args: string[], debug?: boolean, exec?: ExecDelegate) {
-    this.debug = debug ?? false;
-    this.globalArgs = args;
-    this.execImpl = exec ?? realExec;
+    this.debug = debug ?? false
+    this.globalArgs = args
+    this.execImpl = exec ?? realExec
 
     // Capture --stack-yaml if given
-    const stackYamlIdx = args.indexOf("--stack-yaml");
-    const stackYamlArg = stackYamlIdx >= 0 ? args[stackYamlIdx + 1] : null;
+    const stackYamlIdx = args.indexOf('--stack-yaml')
+    const stackYamlArg = stackYamlIdx >= 0 ? args[stackYamlIdx + 1] : null
 
-    this.config = stackYamlArg ?? process.env.STACK_YAML ?? "stack.yaml";
+    this.config = stackYamlArg ?? process.env.STACK_YAML ?? 'stack.yaml'
 
     // Capture --resolver if given
-    const resolverIdx = args.indexOf("--resolver");
-    const resolverArg = resolverIdx >= 0 ? args[resolverIdx + 1] : null;
+    const resolverIdx = args.indexOf('--resolver')
+    const resolverArg = resolverIdx >= 0 ? args[resolverIdx + 1] : null
 
-    this.resolver = resolverArg;
+    this.resolver = resolverArg
 
     // Infer nightly if not given
-    if (!this.resolver && path.basename(this.config) === "stack-nightly.yaml") {
-      this.resolver = "nightly";
-      this.globalArgs.push("--resolver");
-      this.globalArgs.push("nightly");
+    if (!this.resolver && path.basename(this.config) === 'stack-nightly.yaml') {
+      this.resolver = 'nightly'
+      this.globalArgs.push('--resolver')
+      this.globalArgs.push('nightly')
     }
   }
 
   async installed(): Promise<boolean> {
-    const ec = await this.execImpl.exec("which", ["stack"], {
+    const ec = await this.execImpl.exec('which', ['stack'], {
       silent: true,
-      ignoreReturnCode: true,
-    });
-    return ec == 0;
+      ignoreReturnCode: true
+    })
+    return ec == 0
   }
 
   async install(): Promise<void> {
-    const url = "https://get.haskellstack.org";
-    const tmp = "install-stack.sh";
-    await this.execImpl.exec("curl", ["-sSL", "-o", tmp, url]);
-    await this.execImpl.exec("sh", [tmp]);
-    fs.rmSync(tmp);
+    const url = 'https://get.haskellstack.org'
+    const tmp = 'install-stack.sh'
+    await this.execImpl.exec('curl', ['-sSL', '-o', tmp, url])
+    await this.execImpl.exec('sh', [tmp])
+    fs.rmSync(tmp)
   }
 
   async upgrade(): Promise<number> {
     // Avoid this.exec because we don't need/want globalArgs
-    return await this.execImpl.exec("stack", ["upgrade"]);
+    return await this.execImpl.exec('stack', ['upgrade'])
   }
 
   async setup(args: string[]): Promise<number> {
-    return await this.exec(["setup"].concat(args));
+    return await this.exec(['setup'].concat(args))
   }
 
   async installCompilerTools(tools: string[]): Promise<number> {
     if (tools.length > 0) {
-      return await this.exec(["install", "--copy-compiler-tool"].concat(tools));
+      return await this.exec(['install', '--copy-compiler-tool'].concat(tools))
     }
 
     // No tools to install
-    return 0;
+    return 0
   }
 
   async buildDependencies(args: string[]): Promise<number> {
-    return await this.buildNoTest(["--dependencies-only"].concat(args));
+    return await this.buildNoTest(['--dependencies-only'].concat(args))
   }
 
   async buildNoTest(args: string[]): Promise<number> {
-    return await this.build(["--test", "--no-run-tests"].concat(args));
+    return await this.build(['--test', '--no-run-tests'].concat(args))
   }
 
   async buildTest(args: string[]): Promise<number> {
-    return await this.build(["--test"].concat(args));
+    return await this.build(['--test'].concat(args))
   }
 
   async build(args: string[]): Promise<number> {
-    return await this.exec(["build"].concat(args));
+    return await this.exec(['build'].concat(args))
   }
 
   async path(): Promise<StackPath> {
-    return await this.parse(["path"], parseStackPath);
+    return await this.parse(['path'], parseStackPath)
   }
 
   async query(): Promise<StackQuery> {
-    return await this.parse(["query"], parseStackQuery);
+    return await this.parse(['query'], parseStackQuery)
   }
 
   async which(cmd: string): Promise<boolean> {
-    const ec = await this.exec(["exec", "--", "which", cmd], {
-      ignoreReturnCode: true,
-    });
-    return ec === 0;
+    const ec = await this.exec(['exec', '--', 'which', cmd], {
+      ignoreReturnCode: true
+    })
+    return ec === 0
   }
 
   async parse<A>(args: string[], f: (stdout: string) => A): Promise<A> {
-    const stdout = await this.read(args);
-    return f(stdout);
+    const stdout = await this.read(args)
+    return f(stdout)
   }
 
   async read(args: string[]): Promise<string> {
-    let stdout = "";
+    let stdout = ''
 
     const options: ExecOptions = {
       listeners: {
         stdout: (data: Buffer) => {
-          stdout += data.toString();
-        },
-      },
-    };
+          stdout += data.toString()
+        }
+      }
+    }
 
     if (!this.debug) {
       // If not debugging, hide the output being read
-      options.outStream = fs.createWriteStream(devNull);
+      options.outStream = fs.createWriteStream(devNull)
     }
 
-    await this.exec(args, options);
-    return stdout;
+    await this.exec(args, options)
+    return stdout
   }
 
   private async exec(args: string[], options?: ExecOptions): Promise<number> {
-    return await this.execImpl.exec(
-      "stack",
-      this.globalArgs.concat(args),
-      options,
-    );
+    return await this.execImpl.exec('stack', this.globalArgs.concat(args), options)
   }
 }

--- a/src/stack-yaml.test.ts
+++ b/src/stack-yaml.test.ts
@@ -1,101 +1,76 @@
-import { describe, expect, test, vi } from "vitest";
+import {describe, expect, test, vi} from 'vitest'
 
-import { parseStackYaml, getStackDirectories } from "./stack-yaml.js";
-import { StackCLI } from "./stack-cli.js";
+import {parseStackYaml, getStackDirectories} from './stack-yaml.js'
+import {StackCLI} from './stack-cli.js'
 
-const testStackRoot = "/home/me/.stack";
-const testPrograms = `${testStackRoot}/programs/x86_64-linux`;
+const testStackRoot = '/home/me/.stack'
+const testPrograms = `${testStackRoot}/programs/x86_64-linux`
 const testStackPathYaml = `
 stack-root: ${testStackRoot}
 programs: ${testPrograms}
-`;
+`
 
 function mockStackCLI(): StackCLI {
-  const stack = new StackCLI([]);
+  const stack = new StackCLI([])
 
-  vi.spyOn(stack, "read").mockImplementation(
-    (args: string[]): Promise<string> => {
-      // Stringify to avoid array-comparison pitfalls
-      const expected = ["path", "--stack-root", "--programs"].toString();
-      const given = args.toString();
+  vi.spyOn(stack, 'read').mockImplementation((args: string[]): Promise<string> => {
+    // Stringify to avoid array-comparison pitfalls
+    const expected = ['path', '--stack-root', '--programs'].toString()
+    const given = args.toString()
 
-      if (given !== expected) {
-        throw new Error(
-          `StackCLI.read() is only mocked for ${expected}, saw ${given}`,
-        );
-      }
+    if (given !== expected) {
+      throw new Error(`StackCLI.read() is only mocked for ${expected}, saw ${given}`)
+    }
 
-      return Promise.resolve(testStackPathYaml);
-    },
-  );
+    return Promise.resolve(testStackPathYaml)
+  })
 
-  return stack;
+  return stack
 }
 
-describe("getStackDirectories", () => {
-  test("stackRoot, stackPrograms", async () => {
-    const stackYaml = parseStackYaml("resolver: lts-22\n");
-    const stack = mockStackCLI();
+describe('getStackDirectories', () => {
+  test('stackRoot, stackPrograms', async () => {
+    const stackYaml = parseStackYaml('resolver: lts-22\n')
+    const stack = mockStackCLI()
 
-    const stackDirectories = await getStackDirectories(stackYaml, stack, "");
+    const stackDirectories = await getStackDirectories(stackYaml, stack, '')
 
-    expect(stackDirectories.stackRoot).toEqual(testStackRoot);
-    expect(stackDirectories.stackPrograms).toEqual(testPrograms);
-  });
+    expect(stackDirectories.stackRoot).toEqual(testStackRoot)
+    expect(stackDirectories.stackPrograms).toEqual(testPrograms)
+  })
 
-  describe("stackWorks", () => {
-    test("without packages", async () => {
-      const stackYaml = parseStackYaml("resolver: lts-22\n");
-      const stack = mockStackCLI();
+  describe('stackWorks', () => {
+    test('without packages', async () => {
+      const stackYaml = parseStackYaml('resolver: lts-22\n')
+      const stack = mockStackCLI()
 
-      const stackDirectories = await getStackDirectories(
-        stackYaml,
-        stack,
-        "/home/me/code/project",
-      );
+      const stackDirectories = await getStackDirectories(stackYaml, stack, '/home/me/code/project')
 
-      expect(stackDirectories.stackWorks).toEqual([
-        "/home/me/code/project/.stack-work",
-      ]);
-    });
+      expect(stackDirectories.stackWorks).toEqual(['/home/me/code/project/.stack-work'])
+    })
 
-    test("with packages: [.]", async () => {
-      const stackYaml = parseStackYaml("resolver: lts-22\npackages:\n- .");
-      const stack = mockStackCLI();
+    test('with packages: [.]', async () => {
+      const stackYaml = parseStackYaml('resolver: lts-22\npackages:\n- .')
+      const stack = mockStackCLI()
 
-      const stackDirectories = await getStackDirectories(
-        stackYaml,
-        stack,
-        "/home/me/code/project",
-      );
+      const stackDirectories = await getStackDirectories(stackYaml, stack, '/home/me/code/project')
 
-      expect(stackDirectories.stackWorks).toEqual([
-        "/home/me/code/project/.stack-work",
-      ]);
-    });
+      expect(stackDirectories.stackWorks).toEqual(['/home/me/code/project/.stack-work'])
+    })
 
-    test("with subpackages", async () => {
+    test('with subpackages', async () => {
       const stackYaml = parseStackYaml(
-        [
-          "resolver: lts-22",
-          "packages:",
-          "  - subproject1",
-          "  - subproject2",
-        ].join("\n"),
-      );
-      const stack = mockStackCLI();
+        ['resolver: lts-22', 'packages:', '  - subproject1', '  - subproject2'].join('\n')
+      )
+      const stack = mockStackCLI()
 
-      const stackDirectories = await getStackDirectories(
-        stackYaml,
-        stack,
-        "/home/me/code/project",
-      );
+      const stackDirectories = await getStackDirectories(stackYaml, stack, '/home/me/code/project')
 
       expect(stackDirectories.stackWorks).toEqual([
-        "/home/me/code/project/.stack-work",
-        "/home/me/code/project/subproject1/.stack-work",
-        "/home/me/code/project/subproject2/.stack-work",
-      ]);
-    });
-  });
-});
+        '/home/me/code/project/.stack-work',
+        '/home/me/code/project/subproject1/.stack-work',
+        '/home/me/code/project/subproject2/.stack-work'
+      ])
+    })
+  })
+})

--- a/src/stack-yaml.ts
+++ b/src/stack-yaml.ts
@@ -1,62 +1,62 @@
-import * as fs from "fs";
-import { join as pathJoin } from "path";
-import * as yaml from "js-yaml";
+import * as fs from 'fs'
+import {join as pathJoin} from 'path'
+import * as yaml from 'js-yaml'
 
-import { StackCLI } from "./stack-cli.js"
+import {StackCLI} from './stack-cli.js'
 
 export type StackYaml = {
-  resolver: string;
-  packages: string[] | null;
-  "local-programs-path": string | null;
-};
+  resolver: string
+  packages: string[] | null
+  'local-programs-path': string | null
+}
 
 export function readStackYamlSync(path: string): StackYaml {
-  const contents = fs.readFileSync(path, { encoding: "utf-8" });
-  return parseStackYaml(contents);
+  const contents = fs.readFileSync(path, {encoding: 'utf-8'})
+  return parseStackYaml(contents)
 }
 
 export function parseStackYaml(contents: string): StackYaml {
-  return yaml.load(contents) as StackYaml;
+  return yaml.load(contents) as StackYaml
 }
 
 export type StackDirectories = {
-  stackRoot: string;
-  stackPrograms: string;
-  stackWorks: string[];
-};
+  stackRoot: string
+  stackPrograms: string
+  stackWorks: string[]
+}
 
 // Internal type for parsing Yaml output from `stack path`
 type StackPath = {
-  "stack-root": string;
-  programs: string;
-};
+  'stack-root': string
+  programs: string
+}
 
 export async function getStackDirectories(
   stackYaml: StackYaml,
   stack: StackCLI,
-  workingDirectory?: string,
+  workingDirectory?: string
 ): Promise<StackDirectories> {
-  const cwd = workingDirectory ?? process.cwd();
+  const cwd = workingDirectory ?? process.cwd()
 
   // Only use --stack-root and --programs, which (as of stack v2.15.3) won't
   // load the environment and install GHC, etc. These are the only options
   // currently safe to make use of outside of caching.
-  const output = await stack.read(["path", "--stack-root", "--programs"]);
-  const stackPath = yaml.load(output) as StackPath;
-  const stackWorks = packagesStackWorks(stackYaml, cwd);
+  const output = await stack.read(['path', '--stack-root', '--programs'])
+  const stackPath = yaml.load(output) as StackPath
+  const stackWorks = packagesStackWorks(stackYaml, cwd)
 
   return {
-    stackRoot: stackPath["stack-root"],
+    stackRoot: stackPath['stack-root'],
     stackPrograms: stackPath.programs,
-    stackWorks,
-  };
+    stackWorks
+  }
 }
 
 function packagesStackWorks(stackYaml: StackYaml, cwd: string): string[] {
   // We always include ./.stack-work, so filter the "." element if present
   const packageStackWorks = (stackYaml.packages ?? [])
-    .filter((p) => p !== ".")
-    .map((p) => pathJoin(cwd, p, ".stack-work"));
+    .filter(p => p !== '.')
+    .map(p => pathJoin(cwd, p, '.stack-work'))
 
-  return [pathJoin(cwd, ".stack-work")].concat(packageStackWorks);
+  return [pathJoin(cwd, '.stack-work')].concat(packageStackWorks)
 }

--- a/src/with-cache.test.ts
+++ b/src/with-cache.test.ts
@@ -1,94 +1,87 @@
-import { expect, test, vi } from "vitest";
+import {expect, test, vi} from 'vitest'
 
-import { getCacheKeys } from "./get-cache-keys.js";
-import {
-  CacheDelegate,
-  DEFAULT_CACHE_OPTIONS,
-  withCache,
-} from "./with-cache.js";
+import {getCacheKeys} from './get-cache-keys.js'
+import {CacheDelegate, DEFAULT_CACHE_OPTIONS, withCache} from './with-cache.js'
 
 const cache: CacheDelegate = {
-  restoreCache: vi.fn(() => Promise.resolve("")),
-  saveCache: vi.fn(() => Promise.resolve(0)),
-};
+  restoreCache: vi.fn(() => Promise.resolve('')),
+  saveCache: vi.fn(() => Promise.resolve(0))
+}
 
-const restoreCacheMock = vi.spyOn(cache, "restoreCache");
+const restoreCacheMock = vi.spyOn(cache, 'restoreCache')
 
 async function testFunction(): Promise<number> {
-  return 42;
+  return 42
 }
 
 async function testFunctionThrows(): Promise<number> {
-  throw new Error("Boom");
+  throw new Error('Boom')
 }
 
 function simulateCacheHit(
   _paths: string[],
   primaryKey: string,
-  _restoreKeys?: string[],
+  _restoreKeys?: string[]
 ): Promise<string | undefined> {
-  return Promise.resolve(primaryKey);
+  return Promise.resolve(primaryKey)
 }
 
 function simulateCacheMiss(
   _paths: string[],
   primaryKey: string,
-  _restoreKeys?: string[],
+  _restoreKeys?: string[]
 ): Promise<string | undefined> {
-  return Promise.resolve(primaryKey.replace(/-*$/, "-XXX"));
+  return Promise.resolve(primaryKey.replace(/-*$/, '-XXX'))
 }
 
-test("withCache skips on primary-key hit", async () => {
-  const cachePaths = ["/a", "/b"];
-  const cacheKeys = getCacheKeys(["a-b", "c", "d"]);
-  restoreCacheMock.mockImplementation(simulateCacheHit);
+test('withCache skips on primary-key hit', async () => {
+  const cachePaths = ['/a', '/b']
+  const cacheKeys = getCacheKeys(['a-b', 'c', 'd'])
+  restoreCacheMock.mockImplementation(simulateCacheHit)
 
   const result = await withCache(
     cachePaths,
     cacheKeys,
     testFunction,
-    { ...DEFAULT_CACHE_OPTIONS, silent: true },
-    cache,
-  );
+    {...DEFAULT_CACHE_OPTIONS, silent: true},
+    cache
+  )
 
-  expect(result).toBeUndefined();
+  expect(result).toBeUndefined()
   expect(cache.restoreCache).toHaveBeenCalledWith(
     cachePaths,
     cacheKeys.primaryKey,
-    cacheKeys.restoreKeys,
-  );
-  expect(cache.saveCache).not.toHaveBeenCalled();
-});
+    cacheKeys.restoreKeys
+  )
+  expect(cache.saveCache).not.toHaveBeenCalled()
+})
 
-test("withCache acts and saves if no primary-key hit", async () => {
-  const cachePaths = ["/a", "/b"];
-  const cacheKeys = getCacheKeys(["a-b", "c", "d"]);
-  restoreCacheMock.mockImplementation(simulateCacheMiss);
+test('withCache acts and saves if no primary-key hit', async () => {
+  const cachePaths = ['/a', '/b']
+  const cacheKeys = getCacheKeys(['a-b', 'c', 'd'])
+  restoreCacheMock.mockImplementation(simulateCacheMiss)
 
   const result = await withCache(
     cachePaths,
     cacheKeys,
     testFunction,
-    { ...DEFAULT_CACHE_OPTIONS, silent: true },
-    cache,
-  );
+    {...DEFAULT_CACHE_OPTIONS, silent: true},
+    cache
+  )
 
-  expect(result).toEqual(42);
+  expect(result).toEqual(42)
   expect(cache.restoreCache).toHaveBeenCalledWith(
     cachePaths,
     cacheKeys.primaryKey,
-    cacheKeys.restoreKeys,
-  );
-  expect(cache.saveCache).toHaveBeenCalledWith(
-    cachePaths,
-    cacheKeys.primaryKey,
-  );
-});
+    cacheKeys.restoreKeys
+  )
+  expect(cache.saveCache).toHaveBeenCalledWith(cachePaths, cacheKeys.primaryKey)
+})
 
-test("withCache can be configured to act and save anyway", async () => {
-  const cachePaths = ["/a", "/b"];
-  const cacheKeys = getCacheKeys(["a-b", "c", "d"]);
-  restoreCacheMock.mockImplementation(simulateCacheHit);
+test('withCache can be configured to act and save anyway', async () => {
+  const cachePaths = ['/a', '/b']
+  const cacheKeys = getCacheKeys(['a-b', 'c', 'd'])
+  restoreCacheMock.mockImplementation(simulateCacheHit)
 
   const result = await withCache(
     cachePaths,
@@ -97,51 +90,51 @@ test("withCache can be configured to act and save anyway", async () => {
     {
       ...DEFAULT_CACHE_OPTIONS,
       skipOnHit: false,
-      silent: true,
+      silent: true
     },
-    cache,
-  );
+    cache
+  )
 
-  expect(result).toEqual(42);
+  expect(result).toEqual(42)
   expect(cache.restoreCache).toHaveBeenCalledWith(
     cachePaths,
     cacheKeys.primaryKey,
-    cacheKeys.restoreKeys,
-  );
+    cacheKeys.restoreKeys
+  )
 
   // This step is still skipped
-  expect(cache.saveCache).not.toHaveBeenCalled();
-});
+  expect(cache.saveCache).not.toHaveBeenCalled()
+})
 
-test("withCache does not save on error", async () => {
-  const cachePaths = ["/a", "/b"];
-  const cacheKeys = getCacheKeys(["a-b", "c", "d"]);
-  restoreCacheMock.mockImplementation(simulateCacheMiss);
+test('withCache does not save on error', async () => {
+  const cachePaths = ['/a', '/b']
+  const cacheKeys = getCacheKeys(['a-b', 'c', 'd'])
+  restoreCacheMock.mockImplementation(simulateCacheMiss)
 
   await expect(async () => {
     await withCache(
       cachePaths,
       cacheKeys,
       testFunctionThrows,
-      { ...DEFAULT_CACHE_OPTIONS, silent: true },
-      cache,
-    );
-  }).rejects.toThrow();
+      {...DEFAULT_CACHE_OPTIONS, silent: true},
+      cache
+    )
+  }).rejects.toThrow()
 
   expect(cache.restoreCache).toHaveBeenCalledWith(
     cachePaths,
     cacheKeys.primaryKey,
-    cacheKeys.restoreKeys,
-  );
+    cacheKeys.restoreKeys
+  )
 
   // This step is skipped
-  expect(cache.saveCache).not.toHaveBeenCalled();
-});
+  expect(cache.saveCache).not.toHaveBeenCalled()
+})
 
-test("withCache can be configured to save on error", async () => {
-  const cachePaths = ["/a", "/b"];
-  const cacheKeys = getCacheKeys(["a-b", "c", "d"]);
-  restoreCacheMock.mockImplementation(simulateCacheMiss);
+test('withCache can be configured to save on error', async () => {
+  const cachePaths = ['/a', '/b']
+  const cacheKeys = getCacheKeys(['a-b', 'c', 'd'])
+  restoreCacheMock.mockImplementation(simulateCacheMiss)
 
   await expect(async () => {
     await withCache(
@@ -151,20 +144,17 @@ test("withCache can be configured to save on error", async () => {
       {
         ...DEFAULT_CACHE_OPTIONS,
         saveOnError: true,
-        silent: true,
+        silent: true
       },
-      cache,
-    );
-  }).rejects.toThrow();
+      cache
+    )
+  }).rejects.toThrow()
 
   expect(cache.restoreCache).toHaveBeenCalledWith(
     cachePaths,
     cacheKeys.primaryKey,
-    cacheKeys.restoreKeys,
-  );
+    cacheKeys.restoreKeys
+  )
 
-  expect(cache.saveCache).toHaveBeenCalledWith(
-    cachePaths,
-    cacheKeys.primaryKey,
-  );
-});
+  expect(cache.saveCache).toHaveBeenCalledWith(cachePaths, cacheKeys.primaryKey)
+})

--- a/src/with-cache.ts
+++ b/src/with-cache.ts
@@ -1,27 +1,27 @@
-import * as core from "@actions/core";
-import * as realCache from "@actions/cache";
-import type { CacheKeys } from "./get-cache-keys.js";
+import * as core from '@actions/core'
+import * as realCache from '@actions/cache'
+import type {CacheKeys} from './get-cache-keys.js'
 
 export type CacheOptions = {
-  skipOnHit: boolean;
-  saveOnError: boolean;
-  silent: boolean;
-};
+  skipOnHit: boolean
+  saveOnError: boolean
+  silent: boolean
+}
 
 export const DEFAULT_CACHE_OPTIONS = {
   skipOnHit: true,
   saveOnError: false,
-  silent: false,
-};
+  silent: false
+}
 
 export interface CacheDelegate {
   // Mirrors @actions/cache: a miss resolves to undefined
   restoreCache: (
     paths: string[],
     primaryKey: string,
-    restoreKeys?: string[],
-  ) => Promise<string | undefined>;
-  saveCache: (paths: string[], key: string) => Promise<number>;
+    restoreKeys?: string[]
+  ) => Promise<string | undefined>
+  saveCache: (paths: string[], key: string) => Promise<number>
 }
 
 export async function withCache<T>(
@@ -29,55 +29,51 @@ export async function withCache<T>(
   keys: CacheKeys,
   fn: () => Promise<T>,
   options: CacheOptions = DEFAULT_CACHE_OPTIONS,
-  cache?: CacheDelegate,
+  cache?: CacheDelegate
 ): Promise<T | undefined> {
-  const cacheImpl = cache ?? realCache;
-  const { skipOnHit, saveOnError, silent } = options;
+  const cacheImpl = cache ?? realCache
+  const {skipOnHit, saveOnError, silent} = options
 
   if (!silent) {
-    core.info(`Cached paths:\n - ${paths.join("\n - ")}`);
-    core.info(`Cache key: ${keys.primaryKey}`);
-    core.info(`Cache restore keys:\n - ${keys.restoreKeys.join("\n - ")}`);
+    core.info(`Cached paths:\n - ${paths.join('\n - ')}`)
+    core.info(`Cache key: ${keys.primaryKey}`)
+    core.info(`Cache restore keys:\n - ${keys.restoreKeys.join('\n - ')}`)
   }
 
-  const restoredKey = await cacheImpl.restoreCache(
-    paths,
-    keys.primaryKey,
-    keys.restoreKeys,
-  );
+  const restoredKey = await cacheImpl.restoreCache(paths, keys.primaryKey, keys.restoreKeys)
 
-  const primaryKeyHit = restoredKey == keys.primaryKey;
+  const primaryKeyHit = restoredKey == keys.primaryKey
 
   if (restoredKey) {
     if (!silent) {
-      core.info(`Cache restored from key: ${restoredKey}`);
+      core.info(`Cache restored from key: ${restoredKey}`)
     }
   } else {
-    core.warning("No cache found");
+    core.warning('No cache found')
   }
 
   if (primaryKeyHit && skipOnHit && !saveOnError) {
     if (!silent) {
-      core.info("Skipping due to primary key hit");
+      core.info('Skipping due to primary key hit')
     }
-    return;
+    return
   }
 
-  let result: T;
+  let result: T
 
   try {
-    result = await fn();
+    result = await fn()
 
     if (!primaryKeyHit) {
-      await cacheImpl.saveCache(paths, keys.primaryKey);
+      await cacheImpl.saveCache(paths, keys.primaryKey)
     }
   } catch (ex) {
     if (saveOnError && !primaryKeyHit) {
-      await cacheImpl.saveCache(paths, keys.primaryKey);
+      await cacheImpl.saveCache(paths, keys.primaryKey)
     }
 
-    throw ex;
+    throw ex
   }
 
-  return result;
+  return result
 }


### PR DESCRIPTION
2 of 3 in the split of #427: the mass prettier reformat. No behavior change.

Stack:

- #427 — boilerplate/modernization (base `main`)
- **this PR** — prettier config + whole-repo reformat (base `modernize-template`)
- #434 — tests (base `prettier-reformat`)

## What

`main` already had prettier as a devDependency and `format`/`format-check`
scripts, but no config file and no CI step, so nothing enforced a style.

- `.prettierrc`, copied from
  [typescript-action-template](https://github.com/freckle/typescript-action-template):
  `printWidth` 100, `semi` false, `singleQuote` true, `bracketSpacing` false,
  `trailingComma` none, `arrowParens` avoid
- `pnpm format-check` added to `ci.yml`
- `README.md`: one line documenting `pnpm format` / `pnpm format-check`
- the output of `pnpm format` (`prettier --write "**/*.ts"`) over `src/`

Every `src/` hunk here is prettier output. Nothing was hand-edited.

## Evidence

`dist/index.js` rebuilds byte-for-byte identical to #427's, and coverage is
unchanged at 48.27% lines / 62.12% branches / 53.19% functions.

Local run on Node 24.20.0, pnpm 11.24.0 (all exit 0):

| command | exit |
| --- | --- |
| `pnpm install --frozen-lockfile` | 0 |
| `pnpm format-check` | 0 |
| `pnpm typecheck` | 0 |
| `pnpm lint` | 0 |
| `pnpm knip` | 0 |
| `pnpm coverage` | 0 |
| `pnpm build` (then `git status dist/` clean) | 0 |

## Not in this PR

New tests, and the coverage-threshold raise they justify, are in #434.
