### PR TITLE
test: cover hie, inputs, hash-project, and the rest of StackCLI

### DIFF
--- a/src/dirty-files.test.ts
+++ b/src/dirty-files.test.ts
@@ -2,7 +2,7 @@ import {describe, expect, test} from 'vitest'
 
 import {parseGitStatus, isInterestingFile} from './dirty-files.js'
 
-describe('parseGitStatus', () => {
+describe(parseGitStatus.name, () => {
   test('parse file name, and filters untracked', () => {
     const paths = parseGitStatus(
       [
@@ -34,7 +34,7 @@ describe('parseGitStatus', () => {
   })
 })
 
-describe('isInterestingFile', () => {
+describe(isInterestingFile.name, () => {
   const interesting = [
     'foo.cabal',
     'bar.cabal',

--- a/src/dirty-files.test.ts
+++ b/src/dirty-files.test.ts
@@ -1,5 +1,3 @@
-import {describe, expect, test} from 'vitest'
-
 import {parseGitStatus, isInterestingFile} from './dirty-files.js'
 
 describe(parseGitStatus.name, () => {

--- a/src/envsubst.test.ts
+++ b/src/envsubst.test.ts
@@ -4,7 +4,7 @@ import {envsubst} from './envsubst.js'
 
 const HOME = process.env.HOME
 
-describe('envsubst', () => {
+describe(envsubst.name, () => {
   test('known variables are replaced', () => {
     expect(envsubst('Home is $HOME.')).toEqual(`Home is ${HOME}.`)
   })

--- a/src/envsubst.test.ts
+++ b/src/envsubst.test.ts
@@ -1,5 +1,3 @@
-import {describe, expect, test} from 'vitest'
-
 import {envsubst} from './envsubst.js'
 
 const HOME = process.env.HOME

--- a/src/get-cache-keys.test.ts
+++ b/src/get-cache-keys.test.ts
@@ -1,5 +1,3 @@
-import {expect, test} from 'vitest'
-
 import {getCacheKeys} from './get-cache-keys.js'
 
 test('getCacheKeys', () => {

--- a/src/hash-project.test.ts
+++ b/src/hash-project.test.ts
@@ -1,5 +1,4 @@
 import * as path from 'path'
-import {expect, test, vi} from 'vitest'
 
 vi.mock('@actions/glob', () => ({
   hashFiles: vi.fn((patterns: string) => Promise.resolve(`hash(${patterns})`))

--- a/src/hash-project.test.ts
+++ b/src/hash-project.test.ts
@@ -1,0 +1,18 @@
+import * as path from 'path'
+import {expect, test, vi} from 'vitest'
+
+vi.mock('@actions/glob', () => ({
+  hashFiles: vi.fn((patterns: string) => Promise.resolve(`hash(${patterns})`))
+}))
+
+const {hashFiles} = await import('@actions/glob')
+const {hashProject} = await import('./hash-project.js')
+
+test('hashProject hashes the snapshot, package files, and sources separately', async () => {
+  const hashes = await hashProject('stack-nightly.yaml')
+
+  expect(hashes.snapshot).toEqual('hash(stack-nightly.yaml)')
+  expect(hashes.package).toEqual(`hash(**${path.sep}package.yaml\n**${path.sep}*.cabal\n)`)
+  expect(hashes.sources).toEqual(`hash(**\n!**${path.sep}.stack-work\n!.git\n)`)
+  expect(hashFiles).toHaveBeenCalledTimes(3)
+})

--- a/src/hie.test.ts
+++ b/src/hie.test.ts
@@ -1,0 +1,102 @@
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import {afterEach, describe, expect, test, vi} from 'vitest'
+
+import {GenHIE} from './hie.js'
+import type {ExecDelegate} from './stack-cli.js'
+import {StackCLI} from './stack-cli.js'
+
+const tmpDirs: string[] = []
+
+function tmpHieYaml(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'stack-action-hie-'))
+  tmpDirs.push(dir)
+  const file = path.join(dir, 'hie.yaml')
+  fs.writeFileSync(file, 'cradle:\n')
+  return file
+}
+
+function missingHieYaml(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'stack-action-hie-'))
+  tmpDirs.push(dir)
+  return path.join(dir, 'hie.yaml')
+}
+
+// StackCLI is constructed around an injected ExecDelegate so GenHIE exercises
+// the real command-building path
+function stackWith(exec: ExecDelegate['exec']): StackCLI {
+  return new StackCLI([], false, {exec: vi.fn(exec)})
+}
+
+afterEach(() => {
+  for (const dir of tmpDirs.splice(0)) {
+    fs.rmSync(dir, {recursive: true, force: true})
+  }
+})
+
+describe(GenHIE.name, () => {
+  test('defaults to hie.yaml', () => {
+    expect(new GenHIE(stackWith(() => Promise.resolve(0))).path).toEqual('hie.yaml')
+  })
+
+  test('does nothing when the file does not exist', async () => {
+    const exec = vi.fn(() => Promise.resolve(0))
+    const genHIE = new GenHIE(stackWith(exec), missingHieYaml())
+
+    await genHIE.install()
+    await genHIE.generate()
+
+    expect(exec).not.toHaveBeenCalled()
+  })
+
+  test('installs implicit-hie and regenerates the file when it exists', async () => {
+    const file = tmpHieYaml()
+    const commands: string[][] = []
+
+    const genHIE = new GenHIE(
+      stackWith((command, args, options) => {
+        commands.push([command].concat(args))
+
+        if (args.includes('gen-hie')) {
+          options?.listeners?.stdout?.(Buffer.from('cradle:\n  stack:\n'))
+        }
+
+        return Promise.resolve(0)
+      }),
+      file
+    )
+
+    await genHIE.install()
+    await genHIE.generate()
+
+    expect(commands).toEqual([
+      ['stack', 'install', '--copy-compiler-tool', 'implicit-hie'],
+      ['stack', 'exec', '--', 'which', 'gen-hie'],
+      ['stack', 'exec', '--', 'gen-hie', '--stack']
+    ])
+    expect(fs.readFileSync(file, 'utf-8')).toEqual('cradle:\n  stack:\n')
+  })
+
+  test('warns rather than failing when implicit-hie cannot be installed', async () => {
+    const genHIE = new GenHIE(
+      stackWith(() => Promise.reject(new Error('Boom'))),
+      tmpHieYaml()
+    )
+
+    await expect(genHIE.install()).resolves.toBeUndefined()
+  })
+
+  test('skips generating when gen-hie is not on PATH', async () => {
+    const file = tmpHieYaml()
+
+    const genHIE = new GenHIE(
+      stackWith(() => Promise.resolve(1)),
+      file
+    )
+
+    await genHIE.generate()
+
+    expect(fs.readFileSync(file, 'utf-8')).toEqual('cradle:\n')
+  })
+})

--- a/src/hie.test.ts
+++ b/src/hie.test.ts
@@ -1,7 +1,6 @@
 import * as fs from 'fs'
 import * as os from 'os'
 import * as path from 'path'
-import {afterEach, describe, expect, test, vi} from 'vitest'
 
 import {GenHIE} from './hie.js'
 import type {ExecDelegate} from './stack-cli.js'

--- a/src/inputs.test.ts
+++ b/src/inputs.test.ts
@@ -1,5 +1,3 @@
-import {afterEach, beforeEach, describe, expect, test} from 'vitest'
-
 import {getInputs} from './inputs.js'
 
 // core.getInput() reads INPUT_{NAME}; action.yml defaults are not applied for

--- a/src/inputs.test.ts
+++ b/src/inputs.test.ts
@@ -1,0 +1,123 @@
+import {afterEach, beforeEach, describe, expect, test} from 'vitest'
+
+import {getInputs} from './inputs.js'
+
+// core.getInput() reads INPUT_{NAME}; action.yml defaults are not applied for
+// us, so set the ones action.yml declares a default for.
+const defaults: Record<string, string> = {
+  INPUT_TEST: 'true',
+  INPUT_COLOR: 'true',
+  'INPUT_CACHE-SAVE-ALWAYS': 'false',
+  'INPUT_INSTALL-STACK': 'true',
+  'INPUT_UPGRADE-STACK': 'true',
+  'INPUT_ON-DIRTY-FILES': 'warn'
+}
+
+function setInputs(inputs: Record<string, string>): void {
+  for (const [k, v] of Object.entries({...defaults, ...inputs})) {
+    process.env[k] = v
+  }
+}
+
+describe(getInputs.name, () => {
+  const saved = {...process.env}
+
+  beforeEach(() => {
+    for (const k of Object.keys(process.env)) {
+      if (k.startsWith('INPUT_')) {
+        delete process.env[k]
+      }
+    }
+  })
+
+  afterEach(() => {
+    process.env = {...saved}
+  })
+
+  test('reads action.yml defaults', () => {
+    setInputs({'INPUT_STACK-BUILD-ARGUMENTS': '--fast --pedantic'})
+
+    expect(getInputs()).toEqual({
+      workingDirectory: null,
+      test: true,
+      color: true,
+      stackArguments: [],
+      stackSetupArguments: [],
+      stackQueryArguments: [],
+      stackBuildArgumentsDependencies: ['--fast', '--pedantic'],
+      stackBuildArgumentsBuild: ['--fast', '--pedantic'],
+      stackBuildArgumentsTest: ['--fast', '--pedantic'],
+      cachePrefix: '',
+      cacheSaveAlways: false,
+      onDirtyFiles: 'warn',
+      installStack: true,
+      upgradeStack: true,
+      compilerTools: [],
+      stackYaml: null
+    })
+  })
+
+  test('appends per-step build arguments after the shared ones', () => {
+    setInputs({
+      'INPUT_STACK-BUILD-ARGUMENTS': '--fast',
+      'INPUT_STACK-BUILD-ARGUMENTS-DEPENDENCIES': '--jobs 1',
+      'INPUT_STACK-BUILD-ARGUMENTS-BUILD': '--pedantic',
+      'INPUT_STACK-BUILD-ARGUMENTS-TEST': '--ta=--color'
+    })
+
+    const inputs = getInputs()
+
+    expect(inputs.stackBuildArgumentsDependencies).toEqual(['--fast', '--jobs', '1'])
+    expect(inputs.stackBuildArgumentsBuild).toEqual(['--fast', '--pedantic'])
+    expect(inputs.stackBuildArgumentsTest).toEqual(['--fast', '--ta=--color'])
+  })
+
+  test('splits multi-line arguments as shell words and expands the environment', () => {
+    process.env.SOME_RESOLVER = 'lts-22.7'
+    setInputs({
+      'INPUT_STACK-ARGUMENTS': '--resolver $SOME_RESOLVER\n--system-ghc',
+      'INPUT_COMPILER-TOOLS': 'implicit-hie\nhlint'
+    })
+
+    const inputs = getInputs()
+
+    expect(inputs.stackArguments).toEqual(['--resolver', 'lts-22.7', '--system-ghc'])
+    expect(inputs.compilerTools).toEqual(['implicit-hie', 'hlint'])
+  })
+
+  test('reads booleans, trims working-directory, and keeps deprecated stack-yaml', () => {
+    setInputs({
+      'INPUT_WORKING-DIRECTORY': '  example  ',
+      INPUT_TEST: 'false',
+      INPUT_COLOR: 'false',
+      'INPUT_CACHE-SAVE-ALWAYS': 'true',
+      'INPUT_INSTALL-STACK': 'false',
+      'INPUT_UPGRADE-STACK': 'false',
+      'INPUT_ON-DIRTY-FILES': 'error',
+      'INPUT_CACHE-PREFIX': 'v3/',
+      'INPUT_STACK-QUERY-ARGUMENTS': '--verbose',
+      'INPUT_STACK-SETUP-ARGUMENTS': '--reinstall',
+      'INPUT_STACK-YAML': 'stack-nightly.yaml'
+    })
+
+    const inputs = getInputs()
+
+    expect(inputs.workingDirectory).toEqual('example')
+    expect(inputs.test).toBe(false)
+    expect(inputs.color).toBe(false)
+    expect(inputs.cacheSaveAlways).toBe(true)
+    expect(inputs.installStack).toBe(false)
+    expect(inputs.upgradeStack).toBe(false)
+    expect(inputs.onDirtyFiles).toEqual('error')
+    expect(inputs.cachePrefix).toEqual('v3/')
+    expect(inputs.stackQueryArguments).toEqual(['--verbose'])
+    expect(inputs.stackSetupArguments).toEqual(['--reinstall'])
+    expect(inputs.stackYaml).toEqual('stack-nightly.yaml')
+  })
+
+  test('rejects an invalid on-dirty-files', () => {
+    setInputs({'INPUT_ON-DIRTY-FILES': 'explode'})
+
+    expect(() => getInputs()).toThrow(/Invalid on-dirty-files/)
+  })
+})

--- a/src/parse-stack-path.test.ts
+++ b/src/parse-stack-path.test.ts
@@ -1,5 +1,3 @@
-import {expect, test} from 'vitest'
-
 import {parseStackPath} from './parse-stack-path.js'
 
 const EXAMPLE = [

--- a/src/parse-stack-query.test.ts
+++ b/src/parse-stack-query.test.ts
@@ -1,5 +1,3 @@
-import {expect, test} from 'vitest'
-
 import {parseStackQuery} from './parse-stack-query.js'
 
 const EXAMPLE = [

--- a/src/stack-cli.test.ts
+++ b/src/stack-cli.test.ts
@@ -2,7 +2,6 @@ import * as fs from 'fs'
 import * as os from 'os'
 import * as path from 'path'
 import {ExecOptions} from '@actions/exec'
-import {afterEach, describe, expect, test, vi} from 'vitest'
 
 import {ExecDelegate, StackCLI} from './stack-cli.js'
 

--- a/src/stack-cli.test.ts
+++ b/src/stack-cli.test.ts
@@ -1,5 +1,8 @@
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
 import {ExecOptions} from '@actions/exec'
-import {describe, expect, test, vi} from 'vitest'
+import {afterEach, describe, expect, test, vi} from 'vitest'
 
 import {ExecDelegate, StackCLI} from './stack-cli.js'
 
@@ -7,7 +10,18 @@ const exec: ExecDelegate = {
   exec: vi.fn((_command: string, _args: string[], _options?: ExecOptions) => Promise.resolve(0))
 }
 
-describe('StackCLI', () => {
+// An ExecDelegate that feeds `stdout` to the caller's listener, as @actions/exec
+// does for a real command
+function execReading(stdout: string, ec = 0): ExecDelegate {
+  return {
+    exec: vi.fn((_command: string, _args: string[], options?: ExecOptions) => {
+      options?.listeners?.stdout?.(Buffer.from(stdout))
+      return Promise.resolve(ec)
+    })
+  }
+}
+
+describe(StackCLI.name, () => {
   test('Respects --resolver given', async () => {
     const stackCLI = new StackCLI(['--resolver', 'lts'], false, exec)
 
@@ -104,5 +118,125 @@ describe('StackCLI', () => {
     await stackCLI.build(['--coverage'])
 
     expect(exec.exec).toHaveBeenCalledWith('stack', ['build', '--coverage'], undefined)
+  })
+
+  test('config falls back to $STACK_YAML', () => {
+    const saved = process.env.STACK_YAML
+    process.env.STACK_YAML = 'stack-lts.yaml'
+
+    try {
+      expect(new StackCLI([], false, exec).config).toEqual('stack-lts.yaml')
+    } finally {
+      if (saved === undefined) {
+        delete process.env.STACK_YAML
+      } else {
+        process.env.STACK_YAML = saved
+      }
+    }
+  })
+
+  test('installed', async () => {
+    const stackCLI = new StackCLI([], false, exec)
+
+    expect(await stackCLI.installed()).toBe(true)
+    expect(exec.exec).toHaveBeenCalledWith('which', ['stack'], {
+      silent: true,
+      ignoreReturnCode: true
+    })
+  })
+
+  test('installed is false on a non-zero exit', async () => {
+    const missing: ExecDelegate = {exec: vi.fn(() => Promise.resolve(1))}
+
+    expect(await new StackCLI([], false, missing).installed()).toBe(false)
+  })
+
+  test('upgrade does not pass global arguments', async () => {
+    const stackCLI = new StackCLI(['--resolver', 'lts'], false, exec)
+
+    await stackCLI.upgrade()
+
+    expect(exec.exec).toHaveBeenCalledWith('stack', ['upgrade'])
+  })
+
+  describe('install', () => {
+    const cwd = process.cwd()
+    const dirs: string[] = []
+
+    afterEach(() => {
+      process.chdir(cwd)
+      for (const dir of dirs.splice(0)) {
+        fs.rmSync(dir, {recursive: true, force: true})
+      }
+    })
+
+    test('downloads, runs, and removes the installer', async () => {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'stack-action-install-'))
+      dirs.push(dir)
+      process.chdir(dir)
+
+      // Stand in for `curl -o install-stack.sh`
+      const downloading: ExecDelegate = {
+        exec: vi.fn((command: string) => {
+          if (command === 'curl') {
+            fs.writeFileSync('install-stack.sh', '#!/bin/sh\n')
+          }
+          return Promise.resolve(0)
+        })
+      }
+
+      await new StackCLI([], false, downloading).install()
+
+      expect(downloading.exec).toHaveBeenCalledWith('curl', [
+        '-sSL',
+        '-o',
+        'install-stack.sh',
+        'https://get.haskellstack.org'
+      ])
+      expect(downloading.exec).toHaveBeenCalledWith('sh', ['install-stack.sh'])
+      expect(fs.existsSync(path.join(dir, 'install-stack.sh'))).toBe(false)
+    })
+  })
+
+  test('which', async () => {
+    const stackCLI = new StackCLI([], false, exec)
+
+    expect(await stackCLI.which('gen-hie')).toBe(true)
+    expect(exec.exec).toHaveBeenCalledWith('stack', ['exec', '--', 'which', 'gen-hie'], {
+      ignoreReturnCode: true
+    })
+  })
+
+  test('which is false on a non-zero exit', async () => {
+    const missing: ExecDelegate = {exec: vi.fn(() => Promise.resolve(1))}
+
+    expect(await new StackCLI([], false, missing).which('gen-hie')).toBe(false)
+  })
+
+  test('path parses `stack path` output', async () => {
+    const reading = execReading('stack-root: /root/.stack\nbin-path: /usr/bin\n')
+
+    expect(await new StackCLI([], false, reading).path()).toEqual({
+      'stack-root': '/root/.stack',
+      'bin-path': '/usr/bin'
+    })
+  })
+
+  test('query parses `stack query` output', async () => {
+    const reading = execReading('compiler:\n  actual: ghc-9.6.4\n  wanted: ghc-9.6.4\n')
+
+    expect(await new StackCLI([], false, reading).query()).toEqual({
+      compiler: {actual: 'ghc-9.6.4', wanted: 'ghc-9.6.4'}
+    })
+  })
+
+  test('read hides the output it consumes unless debugging', async () => {
+    const quiet = execReading('one\ntwo\n')
+    expect(await new StackCLI([], false, quiet).read(['path'])).toEqual('one\ntwo\n')
+    expect(vi.mocked(quiet.exec).mock.calls[0][2]?.outStream).toBeDefined()
+
+    const debugging = execReading('one\ntwo\n')
+    expect(await new StackCLI([], true, debugging).read(['path'])).toEqual('one\ntwo\n')
+    expect(vi.mocked(debugging.exec).mock.calls[0][2]?.outStream).toBeUndefined()
   })
 })

--- a/src/stack-yaml.test.ts
+++ b/src/stack-yaml.test.ts
@@ -1,5 +1,3 @@
-import {describe, expect, test, vi} from 'vitest'
-
 import {parseStackYaml, getStackDirectories} from './stack-yaml.js'
 import {StackCLI} from './stack-cli.js'
 

--- a/src/stack-yaml.test.ts
+++ b/src/stack-yaml.test.ts
@@ -28,7 +28,7 @@ function mockStackCLI(): StackCLI {
   return stack
 }
 
-describe('getStackDirectories', () => {
+describe(getStackDirectories.name, () => {
   test('stackRoot, stackPrograms', async () => {
     const stackYaml = parseStackYaml('resolver: lts-22\n')
     const stack = mockStackCLI()

--- a/src/with-cache.test.ts
+++ b/src/with-cache.test.ts
@@ -1,5 +1,3 @@
-import {expect, test, vi} from 'vitest'
-
 import {getCacheKeys} from './get-cache-keys.js'
 import {CacheDelegate, DEFAULT_CACHE_OPTIONS, withCache} from './with-cache.js'
 

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -17,10 +17,10 @@ export default defineConfig({
       // any PR that adds tests.
       // Remove to stop enforcing coverage (also revert ci.yml's pnpm coverage -> pnpm test)
       thresholds: {
-        lines: 48,
-        branches: 62,
-        functions: 53,
-        statements: 48,
+        lines: 84,
+        branches: 84,
+        functions: 91,
+        statements: 84,
       },
     },
   },

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -13,8 +13,7 @@ export default defineConfig({
       // main.ts drives real `stack` invocations; covered by .github/workflows/example.yml
       exclude: ["src/main.ts"],
       // Floors, not goals: set to the coverage the existing suite already
-      // achieves, so the numbers cannot silently regress. Raise them alongside
-      // any PR that adds tests.
+      // achieves, so the numbers cannot silently regress.
       // Remove to stop enforcing coverage (also revert ci.yml's pnpm coverage -> pnpm test)
       thresholds: {
         lines: 84,


### PR DESCRIPTION
3 of 3 in the split of #427: the tests. This is the part with actual judgement calls in it.

Stack:

- #427 — boilerplate/modernization (base `main`)
- #433 — prettier config + whole-repo reformat (base `modernize-template`)
- **this PR** — tests (base `prettier-reformat`)

## What

Coverage of `src/` (excluding `main.ts`) goes from 48.27% to 84.82% of lines.

New test files:

- `src/hie.test.ts`
- `src/inputs.test.ts`
- `src/hash-project.test.ts`

`src/stack-cli.test.ts` gains cases for `config`'s `$STACK_YAML` fallback,
`installed`, `upgrade`, `install`, `which`, `path`, `query`, and `read`'s
handling of `outStream`. `path`/`query`/`read` are exercised through an
`ExecDelegate` that feeds canned stdout to the caller's listener, the way
`@actions/exec` does for a real command.

`describe('foo')` becomes `describe(foo.name)` in the suites that already test
a single imported function (`dirty-files`, `envsubst`, `stack-yaml`,
`stack-cli`), so renaming the function is a type error rather than a stale
string. This was raised on #427; happy to drop it if the answer is no.

Coverage thresholds raised from #427's floor to the new one: 84 lines, 84
branches, 91 functions, 84 statements.

## Evidence

No `src/` change outside test files, and `dist/index.js` is unchanged.

Local run on Node 24.20.0, pnpm 11.24.0 (all exit 0):

| command | exit |
| --- | --- |
| `pnpm install --frozen-lockfile` | 0 |
| `pnpm format-check` | 0 |
| `pnpm typecheck` | 0 |
| `pnpm lint` | 0 |
| `pnpm knip` | 0 |
| `pnpm test` | 0 (11 files, 65 tests) |
| `pnpm coverage` | 0 (84.82% lines / 84.84% branches / 91.48% functions) |
| `pnpm build` (then `git status dist/` clean) | 0 |
